### PR TITLE
Interpolation from particles to centroid

### DIFF
--- a/src/Interpolations/particle_to_grid.jl
+++ b/src/Interpolations/particle_to_grid.jl
@@ -41,7 +41,7 @@ end
                     any(isnan, p_i) && continue
                     ω_i = bilinear_weight(xvertex, p_i, di)
                     ω += ω_i
-                    ωxF += ω_i * @cell(Fp[i, ivertex, jvertex])
+                    ωxF = muladd(ω_i, @cell(Fp[ip, ivertex, jvertex]), ωF)
                 end
             end
         end
@@ -75,7 +75,7 @@ end
                     ω += ω_i
                     ωxF = ntuple(Val(N)) do j
                         Base.@_inline_meta
-                        ωxF[j] + ω_i + @cell(Fp[j][i, ivertex, jvertex])
+                        muladd(ω_i, @cell(Fp[j][i, ivertex, jvertex]), ωxF[j])
                     end
                 end
             end
@@ -118,7 +118,7 @@ end
                         any(isnan, p_i) && continue  # ignore lines below for unused allocations
                         ω_i = bilinear_weight(xvertex, p_i, di)
                         ω += ω_i
-                        ωF += ω_i * @cell(Fp[ip, ivertex, jvertex, kvertex])
+                        ωF = muladd(ω_i, @cell(Fp[ip, ivertex, jvertex, kvertex]), ωF)
                     end
                 end
             end
@@ -158,7 +158,7 @@ end
                         ω += ω_i
                         ωxF = ntuple(Val(N)) do j
                             Base.@_inline_meta
-                            ωxF[j] + ω_i + @cell(Fp[j][i, ivertex, jvertex, kvertex])
+                            muladd(ω_i, @cell(Fp[j][i, ivertex, jvertex, kvertex]), ωxF[j])
                         end
                     end
                 end
@@ -184,9 +184,9 @@ end
 ) where {N,T}
     quote
         Base.@_inline_meta
-        val = one(T)
+        one_T = val = one(T)
         Base.Cartesian.@nexprs $N i ->
-            @inbounds val *= muladd(-abs(a[i] - b[i]), inv(di[i]), one(T))
+            @inbounds val *= muladd(-abs(a[i] - b[i]), inv(di[i]), one_T)
         return val
     end
 end

--- a/src/Interpolations/particle_to_grid_centroid.jl
+++ b/src/Interpolations/particle_to_grid_centroid.jl
@@ -20,7 +20,9 @@ end
 
 ## INTERPOLATION KERNEL 2D
 
-@inbounds function _particle2grid_centroid!(F, Fp, inode, jnode, xi::NTuple{2,T}, p, di) where {T}
+@inbounds function _particle2grid_centroid!(
+    F, Fp, inode, jnode, xi::NTuple{2,T}, p, di
+) where {T}
     px, py = p # particle coordinates
     xvertex = xi[1][inode], xi[2][jnode] # centroid coordinates
     ω, ωxF = 0.0, 0.0 # init weights
@@ -34,7 +36,7 @@ end
         ω += ω_i
         ωxF += ω_i * @cell(Fp[i, inode, jnode])
     end
-            
+
     return F[inode, jnode] = ωxF / ω
 end
 
@@ -57,7 +59,7 @@ end
             muladd(ω_i, @cell(Fp[j][i, inode, jnode]), ωxF[j])
         end
     end
-        
+
     _ω = inv(ω)
     return ntuple(Val(N)) do i
         Base.@_inline_meta
@@ -101,9 +103,9 @@ end
     # iterate over cell
     @inbounds for ip in cellaxes(px)
         p_i = (
-            @cell(px[ip,inode, jnode, knode]),
-            @cell(py[ip,inode, jnode, knode]),
-            @cell(pz[ip,inode, jnode, knode]),
+            @cell(px[ip, inode, jnode, knode]),
+            @cell(py[ip, inode, jnode, knode]),
+            @cell(pz[ip, inode, jnode, knode]),
         )
         any(isnan, p_i) && continue  # ignore lines below for unused allocations
         ω_i = bilinear_weight(xvertex, p_i, di)
@@ -113,7 +115,7 @@ end
             muladd(ω_i, @cell(Fp[j][i, inode, jnode, knode]), ωxF[j])
         end
     end
-    
+
     _ω = inv(ω)
     return ntuple(Val(N)) do i
         Base.@_inline_meta

--- a/src/Interpolations/particle_to_grid_centroid.jl
+++ b/src/Interpolations/particle_to_grid_centroid.jl
@@ -1,0 +1,123 @@
+## LAUNCHERS
+
+function particle2grid_centroid!(F, Fp, xi::NTuple, particle_coords)
+    dxi = grid_size(xi)
+    particle2grid_centroid!(F, Fp, xi, particle_coords, dxi)
+    return nothing
+end
+
+function particle2grid_centroid!(F, Fp, xi::NTuple, particle_coords, dxi)
+    @parallel (@idx size(particle_coords[1])) particle2grid_centroid!(
+        F, Fp, xi, particle_coords, dxi
+    )
+    return nothing
+end
+
+@parallel_indices (I...) function particle2grid_centroid!(F, Fp, xi, particle_coords, di)
+    _particle2grid_centroid!(F, Fp, I..., xi, particle_coords, di)
+    return nothing
+end
+
+## INTERPOLATION KERNEL 2D
+
+@inbounds function _particle2grid_centroid!(F, Fp, inode, jnode, xi::NTuple{2,T}, p, di) where {T}
+    px, py = p # particle coordinates
+    xvertex = xi[1][inode], xi[2][jnode] # centroid coordinates
+    ω, ωxF = 0.0, 0.0 # init weights
+
+    # iterate over cell
+    for i in cellaxes(px)
+        p_i = @cell(px[i, inode, jnode]), @cell(py[i, inode, jnode])
+        # ignore lines below for unused allocations
+        any(isnan, p_i) && continue
+        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω += ω_i
+        ωxF += ω_i * @cell(Fp[i, inode, jnode])
+    end
+            
+    return F[inode, jnode] = ωxF / ω
+end
+
+@inbounds function _particle2grid_centroid!(
+    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, xi::NTuple{2,T3}, p, di
+) where {N,T1,T2,T3}
+    px, py = p # particle coordinates
+    xvertex = xi[1][inode], xi[2][jnode] # centroid coordinates
+    ω, ωxF = 0.0, 0.0 # init weights
+
+    # iterate over cell
+    for i in cellaxes(px)
+        p_i = @cell(px[i, inode, jnode]), @cell(py[i, inode, jnode])
+        # ignore lines below for unused allocations
+        any(isnan, p_i) && continue
+        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω += ω_i
+        ωxF = ntuple(Val(N)) do j
+            Base.@_inline_meta
+            ωxF[j] + ω_i + @cell(Fp[j][i, inode, jnode])
+        end
+    end
+        
+    _ω = inv(ω)
+    return ntuple(Val(N)) do i
+        Base.@_inline_meta
+        F[i][inode, jnode] = ωxF[i] * _ω
+    end
+end
+
+## INTERPOLATION KERNEL 3D
+
+@inbounds function _particle2grid_centroid!(
+    F, Fp, inode, jnode, knode, xi::NTuple{3,T}, p, di
+) where {T}
+    px, py, pz = p # particle coordinates
+    xvertex = xi[1][inode], xi[2][jnode], xi[3][knode] # cell lower-left coordinates
+    ω, ωF = 0.0, 0.0 # init weights
+
+    # iterate over cell
+    @inbounds for ip in cellaxes(px)
+        p_i = (
+            @cell(px[ip, inode, jnode, knode]),
+            @cell(py[ip, inode, jnode, knode]),
+            @cell(pz[ip, inode, jnode, knode]),
+        )
+        any(isnan, p_i) && continue  # ignore lines below for unused allocations
+        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω += ω_i
+        ωF += ω_i * @cell(Fp[ip, inode, jnode, knode])
+    end
+
+    return F[inode, jnode, knode] = ωF * inv(ω)
+end
+
+@inbounds function _particle2grid_centroid!(
+    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, knode, xi::NTuple{3,T3}, p, di
+) where {N,T1,T2,T3}
+    px, py, pz = p # particle coordinates
+    nx, ny, nz = size(F[1])
+    xvertex = xi[1][inode], xi[2][jnode], xi[3][knode] # cell lower-left coordinates
+    ω = 0.0 # init weights
+    ωxF = ntuple(i -> 0.0, Val(N)) # init weights
+
+    # iterate over cell
+    @inbounds for ip in cellaxes(px)
+        p_i = (
+            @cell(px[ip,inode, jnode, knode]),
+            @cell(py[ip,inode, jnode, knode]),
+            @cell(pz[ip,inode, jnode, knode]),
+        )
+        any(isnan, p_i) && continue  # ignore lines below for unused allocations
+        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω += ω_i
+        ωxF = ntuple(Val(N)) do j
+            Base.@_inline_meta
+            ωxF[j] + ω_i + @cell(Fp[j][i, inode, jnode, knode])
+        end
+    end
+    
+    _ω = inv(ω)
+    return ntuple(Val(N)) do i
+        Base.@_inline_meta
+        F[i][inode, jnode, knode] = ωxF[i] * _ω
+    end
+end

--- a/src/JustPIC.jl
+++ b/src/JustPIC.jl
@@ -10,6 +10,7 @@ using CellArrays
 using Preferences
 
 # CUDA.allowscalar(false)
+__precompile__(false)
 
 function set_backend(new_backend::String)
     if !(
@@ -54,6 +55,7 @@ let
     precission = s[2]
     dimension = parse(Int, s[3][1])
     @eval begin
+        println("Backend: $backend")
         @init_parallel_stencil($(Symbol(device)), $(Symbol(precission)), $dimension)
     end
 end
@@ -73,6 +75,9 @@ include("Interpolations/utils.jl")
 
 include("Interpolations/particle_to_grid.jl")
 export particle2grid!
+
+include("Interpolations/particle_to_grid_centroid.jl")
+export particle2grid_centroid!
 
 include("Interpolations/grid_to_particle.jl")
 export grid2particle!, grid2particle_flip!
@@ -95,5 +100,8 @@ export check_injection, inject_particles!, inject_particles_phase!, clean_partic
 
 include("Particles/shuffle.jl")
 export shuffle_particles!
+
+include("Particles/shuffle_periodic.jl")
+export shuffle_particles_periodic!
 
 end # module

--- a/src/Particles/advection.jl
+++ b/src/Particles/advection.jl
@@ -170,9 +170,9 @@ function advect_particle_RK(
         Base.@_propagate_inbounds_meta
         Base.@_inline_meta
         local_lims = local_limits[i]
+
         v =
-            if (local_lims[1][1] < p1[1] < local_lims[1][2]) &&
-                (local_lims[2][1] < p1[2] < local_lims[2][2])
+            if check_local_limits(local_lims, p1)
                 interp_velocity_grid2particle(p1, grid_vi[i], dxi, V[i], idx)
 
             else

--- a/src/Particles/advection.jl
+++ b/src/Particles/advection.jl
@@ -171,16 +171,15 @@ function advect_particle_RK(
         Base.@_inline_meta
         local_lims = local_limits[i]
 
-        v =
-            if check_local_limits(local_lims, p1)
-                interp_velocity_grid2particle(p1, grid_vi[i], dxi, V[i], idx)
+        v = if check_local_limits(local_lims, p1)
+            interp_velocity_grid2particle(p1, grid_vi[i], dxi, V[i], idx)
 
-            else
-                # if this condition is met, it means that the particle
-                # went outside the local rank domain. It will be removed 
-                # during shuffling
-                0.0
-            end
+        else
+            # if this condition is met, it means that the particle
+            # went outside the local rank domain. It will be removed 
+            # during shuffling
+            0.0
+        end
     end
 
     # final advection step


### PR DESCRIPTION
New method `particle2grid_centroid!(Array_centroid, particles_field, xci, particles.coords)` where `xci` is the centroid grid.