### PR TITLE
Cap charecteristic dt for subgrid diffusion

### DIFF
--- a/src/Physics/subgrid_diffusion.jl
+++ b/src/Physics/subgrid_diffusion.jl
@@ -65,7 +65,7 @@ end
         pTᵢ = @cell pT[ip, I...]
 
         # subgrid diffusion of the i-th particle
-        pΔTᵢ = (pTᵢ - pT0ᵢ) * (1 - exp(-d * dt / @cell(dt₀[ip, I...])))
+        pΔTᵢ = (pTᵢ - pT0ᵢ) * (1 - exp(-d * dt / max(@cell(dt₀[ip, I...]), 1e-9))
         @cell pT0[ip, I...] = pT0ᵢ + pΔTᵢ
         @cell pΔT[ip, I...] = pΔTᵢ
     end

--- a/src/Physics/subgrid_diffusion.jl
+++ b/src/Physics/subgrid_diffusion.jl
@@ -65,7 +65,7 @@ end
         pTᵢ = @cell pT[ip, I...]
 
         # subgrid diffusion of the i-th particle
-        pΔTᵢ = (pTᵢ - pT0ᵢ) * (1 - exp(-d * dt / max(@cell(dt₀[ip, I...]), 1e-9))
+        pΔTᵢ = (pTᵢ - pT0ᵢ) * (1 - exp(-d * dt / max(@cell(dt₀[ip, I...]), 1e-9)))
         @cell pT0[ip, I...] = pT0ᵢ + pΔTᵢ
         @cell pΔT[ip, I...] = pΔTᵢ
     end


### PR DESCRIPTION
Caps `dt0` to `max(dt0, 1e-9)` to avoid potential blow-ups.