### PR TITLE
Simplify API for `init_particles`

### DIFF
--- a/docs/src/field_advection2D.md
+++ b/docs/src/field_advection2D.md
@@ -63,7 +63,7 @@ nxcell    = 24 # initial number of particles per cell
 max_xcell = 48 # maximum number of particles per cell
 min_xcell = 14 # minimum number of particles per cell
 particles = init_particles(
-    backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+    backend, nxcell, max_xcell, min_xcell, xvi...
 )
 ```
 

--- a/docs/src/field_advection2D_MPI.md
+++ b/docs/src/field_advection2D_MPI.md
@@ -54,10 +54,6 @@ end
 # staggered grid for the velocity components
 grid_vx = xv, add_ghost_nodes(yc, dy, (0.0, Ly))
 grid_vy = add_ghost_nodes(xc, dx, (0.0, Lx)), yv
-    
-particles = init_particles(
-    backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
-)
 ```
 
 And we continue with business as usual
@@ -67,7 +63,7 @@ nxcell    = 24 # initial number of particles per cell
 max_xcell = 48 # maximum number of particles per cell
 min_xcell = 14 # minimum number of particles per cell
 particles = init_particles(
-    backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+    backend, nxcell, max_xcell, min_xcell, xvi...
 )
 ```
 

--- a/docs/src/field_advection3D.md
+++ b/docs/src/field_advection3D.md
@@ -68,7 +68,7 @@ nxcell    = 24 # initial number of particles per cell
 max_xcell = 48 # maximum number of particles per cell
 min_xcell = 14 # minimum number of particles per cell
 particles = init_particles(
-    backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+    backend, nxcell, max_xcell, min_xcell, xvi...
 )
 ```
 

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -41,11 +41,9 @@ module _2D
     end
 
     function JustPIC._2D.init_particles(
-        ::Type{AMDGPUBackend}, nxcell, max_xcell, min_xcell, x, y, dx, dy, nx, ny
+        ::Type{AMDGPUBackend}, nxcell, max_xcell, min_xcell, x, y
     )
-        return init_particles(
-            AMDGPUBackend, nxcell, max_xcell, min_xcell, (x, y), (dx, dy), (nx, ny)
-        )
+        return init_particles(AMDGPUBackend, nxcell, max_xcell, min_xcell, x, y)
     end
 
     function JustPIC._2D.init_particles(
@@ -100,9 +98,7 @@ module _2D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._2D.inject_particles!(
-        particles::Particles{AMDGPUBackend}, args, grid
-    )
+    function JustPIC._2D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid)
         return inject_particles!(particles, args, grid)
     end
 
@@ -206,7 +202,8 @@ module _3D
 
     @init_parallel_stencil(AMDGPU, Float64, 3)
 
-    import JustPIC: Euler, RungeKutta2, AbstractAdvectionIntegrator, Particles, PassiveMarkers
+    import JustPIC:
+        Euler, RungeKutta2, AbstractAdvectionIntegrator, Particles, PassiveMarkers
     import JustPIC: AbstractBackend, AMDGPUBackend
 
     macro myatomic(expr)
@@ -229,17 +226,9 @@ module _3D
     end
 
     function JustPIC._3D.init_particles(
-        ::Type{AMDGPUBackend}, nxcell, max_xcell, min_xcell, x, y, z, dx, dy, dz, nx, ny, nz
+        ::Type{AMDGPUBackend}, nxcell, max_xcell, min_xcell, x, y, z
     )
-        return init_particles(
-            AMDGPUBackend,
-            nxcell,
-            max_xcell,
-            min_xcell,
-            (x, y, z),
-            (dx, dy, dz),
-            (nx, ny, nz),
-        )
+        return init_particles(AMDGPUBackend, nxcell, max_xcell, min_xcell, x, y, z)
     end
 
     function JustPIC._3D.init_particles(
@@ -292,9 +281,7 @@ module _3D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._3D.inject_particles!(
-        particles::Particles{AMDGPUBackend}, args, grid
-    )
+    function JustPIC._3D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid)
         return inject_particles!(particles, args, grid)
     end
 

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -43,11 +43,9 @@ module _2D
     end
 
     function JustPIC._2D.init_particles(
-        ::Type{CUDABackend}, nxcell, max_xcell, min_xcell, x, y, dx, dy, nx, ny
+        ::Type{CUDABackend}, nxcell, max_xcell, min_xcell, x, y
     )
-        return init_particles(
-            CUDABackend, nxcell, max_xcell, min_xcell, (x, y), (dx, dy), (nx, ny)
-        )
+        return init_particles(CUDABackend, nxcell, max_xcell, min_xcell, x, y)
     end
 
     function JustPIC._2D.init_particles(
@@ -98,9 +96,7 @@ module _2D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._2D.inject_particles!(
-        particles::Particles{CUDABackend}, args, grid
-    )
+    function JustPIC._2D.inject_particles!(particles::Particles{CUDABackend}, args, grid)
         return inject_particles!(particles, args, grid)
     end
 
@@ -166,9 +162,7 @@ module _2D
         return advection!(particles, method, V, grid_vxi, dt)
     end
 
-    function JustPIC._2D.grid2particle!(
-        Fp, xvi, F, particles::PassiveMarkers{CUDABackend}
-    )
+    function JustPIC._2D.grid2particle!(Fp, xvi, F, particles::PassiveMarkers{CUDABackend})
         grid2particle!(Fp, xvi, F, particles)
         return nothing
     end
@@ -211,7 +205,8 @@ module _3D
         )
     end
 
-    import JustPIC: Euler, RungeKutta2, AbstractAdvectionIntegrator, Particles, PassiveMarkers
+    import JustPIC:
+        Euler, RungeKutta2, AbstractAdvectionIntegrator, Particles, PassiveMarkers
     import JustPIC: AbstractBackend
 
     function JustPIC._3D.CA(::Type{CUDABackend}, dims; eltype=Float64)
@@ -226,11 +221,9 @@ module _3D
     end
 
     function JustPIC._3D.init_particles(
-        ::Type{CUDABackend}, nxcell, max_xcell, min_xcell, x, y, z, dx, dy, dz, nx, ny, nz
+        ::Type{CUDABackend}, nxcell, max_xcell, min_xcell, x, y, z
     )
-        return init_particles(
-            CUDABackend, nxcell, max_xcell, min_xcell, (x, y, z), (dx, dy, dz), (nx, ny, nz)
-        )
+        return init_particles(CUDABackend, nxcell, max_xcell, min_xcell, x, y, z)
     end
 
     function JustPIC._3D.init_particles(
@@ -283,9 +276,7 @@ module _3D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._3D.inject_particles!(
-        particles::Particles{CUDABackend}, args, grid
-    )
+    function JustPIC._3D.inject_particles!(particles::Particles{CUDABackend}, args, grid)
         return inject_particles!(particles, args, grid)
     end
 
@@ -339,9 +330,7 @@ module _3D
         return advection!(particles, method, V, grid_vxi, dt)
     end
 
-    function JustPIC._3D.grid2particle!(
-        Fp, xvi, F, particles::PassiveMarkers{CUDABackend}
-    )
+    function JustPIC._3D.grid2particle!(Fp, xvi, F, particles::PassiveMarkers{CUDABackend})
         grid2particle!(Fp, xvi, F, particles)
         return nothing
     end

--- a/scripts/single_particle_advection.jl
+++ b/scripts/single_particle_advection.jl
@@ -41,7 +41,7 @@ function main()
     grid_vy = expand_range(xc), yv
 
     particles = init_particle(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # allocate particle field

--- a/scripts/temperature_advection3D_MPI.jl
+++ b/scripts/temperature_advection3D_MPI.jl
@@ -53,7 +53,7 @@ function main()
     grid_vz = add_ghost_nodes(xc, dx, (0.0, Lx)), add_ghost_nodes(yc, dy, (0.0, Ly)), zv
     
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi, dxi, (nx, ny, nz)
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # Cell fields -------------------------------

--- a/scripts/temperature_advection3d.jl
+++ b/scripts/temperature_advection3d.jl
@@ -48,7 +48,7 @@ function main()
     # Initialize particles -------------------------------
     nxcell, max_xcell, min_xcell = 24, 24, 3
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # Cell fields -------------------------------

--- a/scripts/temperature_advection_AMDGPU.jl
+++ b/scripts/temperature_advection_AMDGPU.jl
@@ -5,34 +5,6 @@ using JustPIC._2D
 const backend = JustPIC.AMDGPUBackend
 using CairoMakie
 
-function init_particles(nxcell, max_xcell, min_xcell, x, y, dx, dy, nx, ny)
-    ni = nx, ny
-    ncells = nx * ny
-    np = max_xcell * ncells
-    px, py = ntuple(_ -> @rand(ni..., celldims=(max_xcell,)) , Val(2))
-
-    inject = @fill(false, nx, ny, eltype=Bool)
-    index = @fill(false, ni..., celldims=(max_xcell,), eltype=Bool) 
-    
-    @parallel_indices (i, j) function fill_coords_index(px, py, index, x, y, dx, dy, nxcell)
-        # lower-left corner of the cell
-        x0, y0 = x[i], y[j]
-        # fill index array
-        for l in 1:nxcell
-            @cell px[l, i, j] = x0 + dx * (@cell(px[l, i, j]) * 0.9 + 0.05)
-            @cell py[l, i, j] = y0 + dy * (@cell(py[l, i, j]) * 0.9 + 0.05)
-            @cell index[l, i, j] = true
-        end
-        return nothing
-    end
-
-    @parallel (1:nx, 1:ny) fill_coords_index(px, py, index, x, y, dx, dy, nxcell) 
-
-    return Particles(
-        (px, py), index, inject, nxcell, max_xcell, min_xcell, np, (nx, ny)
-    )
-end
-
 function expand_range(x::AbstractRange)
     dx = x[2] - x[1]
     n = length(x)
@@ -66,7 +38,7 @@ function main()
     grid_vy = expand_range(xc), yv
 
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # Cell fields -------------------------------

--- a/scripts/temperature_advection_MPI.jl
+++ b/scripts/temperature_advection_MPI.jl
@@ -49,7 +49,7 @@ function main()
     grid_vy = add_ghost_nodes(xc, dx, (0.0, Lx)), yv
     
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # Cell fields -------------------------------

--- a/src/CellArrays/ImplicitGlobalGrid.jl
+++ b/src/CellArrays/ImplicitGlobalGrid.jl
@@ -12,9 +12,7 @@ function update_cell_halo!(x::Vararg{CellArray,N}) where {N}
     return nothing
 end
 
-@parallel_indices (I...) function copy_field!(
-    A::CellArray, B::AbstractArray, ip
-)
+@parallel_indices (I...) function copy_field!(A::CellArray, B::AbstractArray, ip)
     @cell A[ip, I...] = B[I...]
     return nothing
 end

--- a/src/Interpolations/centroid_to_particle.jl
+++ b/src/Interpolations/centroid_to_particle.jl
@@ -239,4 +239,6 @@ end
 
 # shifts the index of the cell bot-left to the left if it is located in the left cell
 @inline shifted_index(pxi, xci, idx) = pxi < xci ? idx - 1 : idx
-@inline shifted_index(pxi::NTuple{N,A}, xci::NTuple{N,B}, idx::NTuple{N,Integer}) where {N,A,B} = ntuple(i -> shifted_index(pxi[i], xci[i], idx[i]), Val(N))
+@inline shifted_index(
+    pxi::NTuple{N,A}, xci::NTuple{N,B}, idx::NTuple{N,Integer}
+) where {N,A,B} = ntuple(i -> shifted_index(pxi[i], xci[i], idx[i]), Val(N))

--- a/src/Interpolations/ndlerp.jl
+++ b/src/Interpolations/ndlerp.jl
@@ -1,17 +1,4 @@
 """
-    lerp(t, v0, v1)
-
-Linearly interpolates between `v0` and `v1` using the parameter `t`.
-
-# Arguments
-- `t`: The interpolation parameter.
-- `v0`: The starting value.
-- `v1`: The ending value.
-
-"""
-@inline lerp(t, v0, v1) = fma(t, v1, fma(-t, v0, v0))
-
-"""
     lerp(v, t::NTuple{nD,T}) where {nD,T}
 
 Linearly interpolates the value `v` between the elements of the tuple `t`.
@@ -21,6 +8,7 @@ This function is specialized for tuples of length `nD`.
 - `v`: The value to be interpolated.
 - `t`: The tuple of values to interpolate between.
 """
-@inline lerp(v, t::NTuple{nD,T})              where {nD,T}   = lerp(v, t, 0, Val(nD - 1))
-@inline lerp(v, t::NTuple{nD,T}, i, ::Val{N}) where {nD,N,T} = lerp(t[N + 1], lerp(v, t, i, Val(N - 1)), lerp(v, t, i + 2^N, Val(N - 1)))
-@inline lerp(v, t::NTuple{nD,T}, i, ::Val{0}) where {nD,T}   = lerp(t[1], v[i + 1], v[i + 2])
+@inline lerp(v, t::NTuple{nD,T})              where {nD,T}    = lerp(v, t, 0, Val(nD - 1))
+@inline lerp(v, t::NTuple{nD,T}, i, ::Val{N}) where {nD,N,T}  = lerp(t[N + 1], lerp(v, t, i, Val(N - 1)), lerp(v, t, i + 2^N, Val(N - 1)))
+@inline lerp(v, t::NTuple{nD,T}, i, ::Val{0}) where {nD,T}    = lerp(t[1], v[i + 1], v[i + 2])
+@inline lerp(t::T, v0::T, v1::T)              where {T<:Real} = fma(t, v1, fma(-t, v0, v0))

--- a/src/Particles/Advection/advection.jl
+++ b/src/Particles/Advection/advection.jl
@@ -1,4 +1,16 @@
 # Main Runge-Kutta advection function for 2D staggered grids
+"""
+    advection!(particles::Particles, method::AbstractAdvectionIntegrator, V, grid_vi::NTuple{N,NTuple{N,T}}, dt)
+
+Advects the particles using the advection scheme defined by `method`.
+
+# Arguments
+- `particles`: Particles object to be advected.
+- `method`: Time integration method (`Euler` or `RungeKutta2`).
+- `V`: Tuple containing `Vx`, `Vy`; and `Vz` in 3D.
+- `grid_vi`: Tuple containin the grids corresponing to `Vx`, `Vy`; and `Vz` in 3D.
+- `dt`: Time step.
+"""
 function advection!(
     particles::Particles,
     method::AbstractAdvectionIntegrator,

--- a/src/Particles/Advection/advection.jl
+++ b/src/Particles/Advection/advection.jl
@@ -8,7 +8,7 @@ Advects the particles using the advection scheme defined by `method`.
 - `particles`: Particles object to be advected.
 - `method`: Time integration method (`Euler` or `RungeKutta2`).
 - `V`: Tuple containing `Vx`, `Vy`; and `Vz` in 3D.
-- `grid_vi`: Tuple containin the grids corresponing to `Vx`, `Vy`; and `Vz` in 3D.
+- `grid_vi`: Tuple containing the grids corresponing to `Vx`, `Vy`; and `Vz` in 3D.
 - `dt`: Time step.
 """
 function advection!(

--- a/src/Particles/Advection/advection.jl
+++ b/src/Particles/Advection/advection.jl
@@ -8,7 +8,7 @@ Advects the particles using the advection scheme defined by `method`.
 - `particles`: Particles object to be advected.
 - `method`: Time integration method (`Euler` or `RungeKutta2`).
 - `V`: Tuple containing `Vx`, `Vy`; and `Vz` in 3D.
-- `grid_vi`: Tuple containing the grids corresponing to `Vx`, `Vy`; and `Vz` in 3D.
+- `grid_vi`: Tuple containing the grids corresponding to `Vx`, `Vy`; and `Vz` in 3D.
 - `dt`: Time step.
 """
 function advection!(

--- a/src/Particles/injection.jl
+++ b/src/Particles/injection.jl
@@ -1,6 +1,17 @@
 ## PARTICLE INJECTION FUNCTIONS
 
+"""
+    inject_particles!(particles::Particles, args, grid)
+
+Injects particles if the number of particles in a given cell is such that `n < particles.min_xcell`.
+
+# Arguments
+- `particles`: The particles object.
+- `args`: `CellArrays`s containing particle fields.
+- `grid`: The grid cell vertices.
+"""
 function inject_particles!(particles::Particles, args, grid)
+    # function implementation goes here
     # unpack
     (; coords, index, min_xcell) = particles
     ni = size(index)
@@ -71,16 +82,8 @@ end
 )
     if mapreduce(x -> x[1] ≤ x[2], &, zip(I, size(index))) &&
         isemptycell(index, min_xcell, I...)
-        _inject_particles_phase!(        
-            particles_phases,
-            args,
-            fields,
-            coords,
-            index,
-            grid,
-            di,
-            min_xcell,
-            I,
+        _inject_particles_phase!(
+            particles_phases, args, fields, coords, index, grid, di, min_xcell, I
         )
     end
     return nothing

--- a/src/Particles/move.jl
+++ b/src/Particles/move.jl
@@ -1,4 +1,15 @@
+"""
+    move_particles!(particles::AbstractParticles, grid, args)
+
+Move particles in the given `particles` container according to the provided `grid` and particles fields in `args`.
+
+# Arguments
+- `particles`: The container of particles to be moved.
+- `grid`: The grid used for particle movement.
+- `args`: `CellArrays`s containing particle fields.
+"""
 function move_particles!(particles::AbstractParticles, grid, args)
+    # implementation goes here
     dxi = compute_dx(grid)
     (; coords, index) = particles
     nxi = size(index)

--- a/src/Particles/particles_utils.jl
+++ b/src/Particles/particles_utils.jl
@@ -7,22 +7,30 @@
     )
 end
 
-@inline function cell_array(x::T, ncells::NTuple{N1,Integer}, ni::NTuple{N2,Integer}) where {T,N1,N2}
+@inline function cell_array(
+    x::T, ncells::NTuple{N1,Integer}, ni::NTuple{N2,Integer}
+) where {T,N1,N2}
     @fill(x, ni..., celldims = ncells, eltype = T)
 end
 
 ## random particles initialization 
+"""
+    init_particles( backend, nxcell, max_xcell, min_xcell, coords::NTuple{N,AbstractArray}, dxᵢ::NTuple{N,T}, nᵢ::NTuple{N,I})
 
-function init_particles(backend, nxcell, max_xcell, min_xcell, x, y, dx, dy, nx, ny)
-    return init_particles(backend, nxcell, max_xcell, min_xcell, (x, y), (dx, dy), (nx, ny))
-end
+Initialize the particles object.
 
-function init_particles(
-    backend, nxcell, max_xcell, min_xcell, x, y, z, dx, dy, dz, nx, ny, nz
-)
-    return init_particles(
-        backend, nxcell, max_xcell, min_xcell, (x, y, z), (dx, dy, dz), (nx, ny, nz)
-    )
+# Arguments
+- `backend`: Device backend
+- `nxcell`: Initial number of particles per cell
+- `max_xcell`: Maximum number of particles per cell
+- `min_xcell`: Minimum number of particles per cell
+- `xvi`: Grid cells vertices
+"""
+function init_particles(backend, nxcell, max_xcell, min_xcell, xvi::Vararg{N,T}) where {N,T}
+    di = compute_dx(xvi)
+    ni = @. length(xvi) - 1
+
+    return init_particles(backend, nxcell, max_xcell, min_xcell, xvi, di, ni)
 end
 
 function init_particles(
@@ -69,10 +77,3 @@ function init_particles(
 
     return Particles(backend, pxᵢ, index, nxcell, max_xcell, min_xcell, np)
 end
-
-# function get_cell(xi::Union{SVector{N,T},NTuple{N,T}}, dxi::NTuple{N,T}) where {N,T<:Real}
-#     ntuple(Val(N)) do i
-#         Base.@_inline_meta
-#         abs(Int64(xi[i] ÷ dxi[i])) + 1
-#     end
-# end

--- a/src/Particles/utils.jl
+++ b/src/Particles/utils.jl
@@ -6,8 +6,7 @@
     return ntuple(i -> grid[i][I[i]], Val(N))
 end
 
-
-@generated function isincell(p::NTuple{N, T}, xci::NTuple{N, T}, dxi::NTuple{N, T}) where {N,T}
+@generated function isincell(p::NTuple{N,T}, xci::NTuple{N,T}, dxi::NTuple{N,T}) where {N,T}
     quote
         Base.@_inline_meta
         bool = true

--- a/src/PassiveMarkers/advection.jl
+++ b/src/PassiveMarkers/advection.jl
@@ -1,10 +1,6 @@
 # Two-step Runge-Kutta advection scheme for marker chains
 function advection!(
-    particles::PassiveMarkers,
-    method::AbstractAdvectionIntegrator,
-    V,
-    grid_vxi,
-    dt,
+    particles::PassiveMarkers, method::AbstractAdvectionIntegrator, V, grid_vxi, dt
 )
     (; coords, np) = particles
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,4 +1,4 @@
-function add_global_ghost_nodes(x::AbstractArray, dx, origin; backend = CPUBackend)
+function add_global_ghost_nodes(x::AbstractArray, dx, origin; backend=CPUBackend)
     x1, x2 = extrema(x)
     xI = round(x1 - dx; sigdigits=5)
     xF = round(x2 + dx; sigdigits=5)
@@ -7,7 +7,7 @@ function add_global_ghost_nodes(x::AbstractArray, dx, origin; backend = CPUBacke
     return x = TA(backend)(x)
 end
 
-function add_ghost_nodes(x::AbstractArray, dx, origin; backend = CPUBackend)
+function add_ghost_nodes(x::AbstractArray, dx, origin; backend=CPUBackend)
     x1, x2 = extrema(x)
     xI = round(x1 - dx; sigdigits=5)
     xF = round(x2 + dx; sigdigits=5)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -1,5 +1,19 @@
 abstract type AbstractParticles end
 
+"""
+    struct Particles{Backend,N,M,I,T1,T2} <: AbstractParticles
+
+A struct representing a collection of particles.
+
+# Arguments
+- `backend`: The backend used for particle computations (CPUBackend, CUDABackend, AMDGPUBackend).
+- `coords`: Coordinates of the particles
+- `index`: Helper array flaggin active particles
+- `nxcell`: Initial number of particles per cell
+- `max_xcell`: Maximum number of particles per cell
+- `min_xcell`: Minimum number of particles per cell
+- `np`: Number of particles
+"""
 struct Particles{Backend,N,M,I,T1,T2} <: AbstractParticles
     coords::NTuple{N,T1}
     index::T2
@@ -18,7 +32,7 @@ struct Particles{Backend,N,M,I,T1,T2} <: AbstractParticles
         np::I,
     ) where {N,I,T1,T2}
         return new{backend,N,max_xcell,I,T1,T2}(
-            coords, index,  nxcell, max_xcell, min_xcell, np
+            coords, index, nxcell, max_xcell, min_xcell, np
         )
     end
 end

--- a/test/test_2D.jl
+++ b/test/test_2D.jl
@@ -46,7 +46,7 @@ vi_stream(x) =  π * 1e-5 * (x - 0.5)
 
     # Initialize particles & particle fields
     particles = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
     pT, = _2D.init_cell_arrays(particles, Val(1))
 
@@ -82,7 +82,7 @@ end
 
     # Initialize particles & particle fields
     particles = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
 
     arrays = SubgridDiffusionCellArrays(particles)
@@ -113,11 +113,11 @@ end
     grid_vy = expand_range(xc), yv
 
     particles1 = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., ni...
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
 
     particles2 = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
 
     @test particles1.min_xcell == particles2.min_xcell
@@ -215,7 +215,7 @@ function advection_test_2D()
     grid_vy = expand_range(xc), yv
 
     particles = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
 
     # Cell fields -------------------------------
@@ -273,7 +273,7 @@ function test_rotating_circle()
     grid_vy = expand_range(xc), yv
 
     particles = _2D.init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...,
     )
 
     # Cell fields -------------------------------

--- a/test/test_3D.jl
+++ b/test/test_3D.jl
@@ -47,7 +47,7 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
 
         # Initialize particles -------------------------------
         particles = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
         pT, = _3D.init_cell_arrays(particles, Val(1))
 
@@ -88,11 +88,11 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
 
         # Initialize particles -------------------------------
         particles1 = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., ni...
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
 
         particles2 = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
 
         @test particles1.min_xcell == particles2.min_xcell
@@ -116,7 +116,7 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
 
         # Initialize particles -------------------------------
         particles = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
     
         arrays = SubgridDiffusionCellArrays(particles)
@@ -175,7 +175,7 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
         # Initialize particles -------------------------------
         nxcell, max_xcell, min_xcell = 24, 24, 3
         particles = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
 
         # Cell fields -------------------------------
@@ -242,7 +242,7 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
         # Initialize particles -------------------------------
         nxcell, max_xcell, min_xcell = 75, 100, 50
         particles = _3D.init_particles(
-            backend, nxcell, max_xcell, min_xcell, xvi, dxi, ni
+            backend, nxcell, max_xcell, min_xcell, xvi...
         )
 
         # Advection test


### PR DESCRIPTION
New syntax:

```julia 
particles = init_particles(backend, nxcell, max_xcell, min_xcell, grid_vertices_x, grid_vertices_y)
```