### PR TITLE
Out-of-place copy method for JP 

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -37,7 +37,7 @@ module _2D
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
     function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
-        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})
@@ -226,7 +226,7 @@ module _3D
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
     function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
-        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 
     function JustPIC._3D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -225,7 +225,7 @@ module _3D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
-    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 2, 0, ROCArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
+    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 3, 0, ROCArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
         return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -36,7 +36,7 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
-    function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+    function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 2, 0, ROCArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
         return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 
@@ -225,7 +225,7 @@ module _3D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
-    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 2, 0, ROCArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
         return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -36,8 +36,8 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
-    function JustPIC._2D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
-        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})
@@ -225,8 +225,8 @@ module _3D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
-    function JustPIC._3D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
-        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, ROCArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 
     function JustPIC._3D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -36,6 +36,10 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
 
+    function JustPIC._2D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
+        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    end
+
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})
         return SubgridDiffusionCellArrays(particles)
     end
@@ -220,6 +224,10 @@ module _3D
 
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/AMDGPUExt/CellArrays.jl"))
+
+    function JustPIC._3D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
+        return Particles(AMDGPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    end
 
     function JustPIC._3D.SubgridDiffusionCellArrays(particles::Particles{AMDGPUBackend})
         return SubgridDiffusionCellArrays(particles)

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -38,9 +38,9 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
 
-    # function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, CuArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
-    #     return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
-    # end
+    function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 2, 0, CuArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
+        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    end
 
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{CUDABackend})
         return SubgridDiffusionCellArrays(particles)
@@ -220,7 +220,7 @@ module _3D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
 
-    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, CuArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, 3, 0, CuArray{Bool, N2}}, nxcell, max_xcell, min_xcell, np) where {N1,N2}
         return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -38,6 +38,10 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
 
+    function JustPIC._2D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
+        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    end
+
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{CUDABackend})
         return SubgridDiffusionCellArrays(particles)
     end
@@ -215,6 +219,10 @@ module _3D
 
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
+
+    function JustPIC._3D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
+        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    end
 
     function JustPIC._3D.SubgridDiffusionCellArrays(particles::Particles{CUDABackend})
         return SubgridDiffusionCellArrays(particles)

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -38,9 +38,9 @@ module _2D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
 
-    function JustPIC._2D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
-        return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
-    end
+    # function JustPIC._2D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, CuArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
+    #     return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
+    # end
 
     function JustPIC._2D.SubgridDiffusionCellArrays(particles::Particles{CUDABackend})
         return SubgridDiffusionCellArrays(particles)
@@ -220,7 +220,7 @@ module _3D
     include(joinpath(@__DIR__, "../src/common.jl"))
     include(joinpath(@__DIR__, "../src/CUDAExt/CellArrays.jl"))
 
-    function JustPIC._3D.Particles(coords, index::CellArray, nxcell, max_xcell, min_xcell, np)
+    function JustPIC._3D.Particles(coords, index::CellArray{StaticArraysCore.SVector{N1, Bool}, N2, 0, CuArray{Bool, N3}}, nxcell, max_xcell, min_xcell, np) where {N1,N2,N3}
         return Particles(CUDABackend, coords, index, nxcell, max_xcell, min_xcell, np)
     end
 

--- a/scripts/rotating_circle.jl
+++ b/scripts/rotating_circle.jl
@@ -1,7 +1,7 @@
 using JustPIC
 using JustPIC._2D
-# Threads is the default backend, 
-# to run on a CUDA GPU load CUDA.jl (i.e. "using CUDA"), 
+# Threads is the default backend,
+# to run on a CUDA GPU load CUDA.jl (i.e. "using CUDA"),
 # and to run on an AMD GPU load AMDGPU.jl (i.e. "using AMDGPU")
 const backend = JustPIC.CPUBackend # Options: CPUBackend, CUDABackend, AMDGPUBackend
 
@@ -40,7 +40,7 @@ function main()
     grid_vxi = grid_vx, grid_vy
 
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
+        backend, nxcell, max_xcell, min_xcell, xvi...
     )
 
     # Cell fields -------------------------------
@@ -59,7 +59,7 @@ function main()
 
     particle_args = pT, = init_cell_arrays(particles, Val(1));
     grid2particle!(pT, xvi, T, particles);
-    
+
     t   = 0
     it  = 0
     t_pic = 0.0

--- a/scripts/temperature_advection_timer.jl
+++ b/scripts/temperature_advection_timer.jl
@@ -1,7 +1,7 @@
 using JustPIC, JustPIC._2D
 
-# Threads is the default backend, 
-# to run on a CUDA GPU load CUDA.jl (i.e. "using CUDA"), 
+# Threads is the default backend,
+# to run on a CUDA GPU load CUDA.jl (i.e. "using CUDA"),
 # and to run on an AMD GPU load AMDGPU.jl (i.e. "using AMDGPU")
 const backend = JustPIC.CPUBackend # Options: CPUBackend, CUDABackend, AMDGPUBackend
 
@@ -41,8 +41,7 @@ function main()
     grid_vy = expand_range(xc), yv
 
     particles = init_particles(
-        backend, nxcell, max_xcell, min_xcell, xvi..., dxi..., nx, ny
-    )
+        backend, nxcell, max_xcell, min_xcell, xvi...)
 
     # Cell fields -------------------------------
     Vx = TA(backend)([vx_stream(x, y) for x in grid_vx[1], y in grid_vx[2]]);
@@ -56,7 +55,7 @@ function main()
     # Advection test
     particle_args = pT, = init_cell_arrays(particles, Val(1));
     grid2particle!(pT, xvi, T, particles);
-    
+
     !isdir("figs") && mkdir("figs")
 
     niter = 5

--- a/src/CellArrays/conversion.jl
+++ b/src/CellArrays/conversion.jl
@@ -31,7 +31,7 @@ function Array(x::T) where {T<:AbstractParticles}
         _Array(getfield(x, i))
     end
     T_clean = remove_parameters(x)
-    return T_clean(cpu_fields...)
+    return T_clean(CPUBackend, cpu_fields...)
 end
 
 _copy(::Nothing) = nothing

--- a/src/JustPIC.jl
+++ b/src/JustPIC.jl
@@ -24,6 +24,6 @@ export AbstractAdvectionIntegrator, Euler, RungeKutta2
 include("JustPIC_CPU.jl")
 
 include("CellArrays/conversion.jl")
-export Array
+export Array, copy
 
 end # module

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -37,8 +37,9 @@ struct Particles{Backend,N,M,I,T1,T2} <: AbstractParticles
     end
 end
 
-Particles(coords, index::CPUCellArray, nxcell, max_xcell, min_xcell, np) =
+function Particles(coords, index::CPUCellArray, nxcell, max_xcell, min_xcell, np)
     Particles(CPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
+end
 
 struct MarkerChain{Backend,N,M,I,T1,T2,TV} <: AbstractParticles
     coords::NTuple{N,T1}

--- a/test/test_2D.jl
+++ b/test/test_2D.jl
@@ -77,6 +77,14 @@ vi_stream(x) =  π * 1e-5 * (x - 0.5)
     @test pT_cpu              isa JustPIC.CellArrays.CPUCellArray
     @test particles_cpu.index.data[:] == Array(particles.index.data)[:]
     @test pT_cpu.data[:]              == Array(pT.data)[:]
+
+    # test copy function
+    particles_copy = copy(particles)
+    pT_copy        = copy(pT)
+    @test particles_copy.index isa JustPIC.CellArrays.CPUCellArray
+    @test pT_copy              isa JustPIC.CellArrays.CPUCellArray
+    @test particles_copy.index.data[:] == particles.index.data[:]
+    @test pT_copy.data[:]              == pT.data[:]
 end
 
 @testset "Subgrid diffusion 2D" begin
@@ -137,26 +145,26 @@ end
     n = 11
     x = range(0, stop=1, length=n)
     xv = x, x
-    
+
     px = rand()
     idx = _2D.cell_index(px, x)
     @test x[idx] ≤ px < x[idx+1]
-    
+
     px, py = rand(2)
     i, j = _2D.cell_index((px,py), xv)
     @test x[i] ≤ px < x[i+1]
     @test x[j] ≤ py < x[j+1]
-    
+
     x = range(0, stop=1, length=n)
     y = range(-1, stop=0, length=n)
     px, py = rand(), -rand()
     idx = cell_index(py, y)
     @test y[idx] ≤ py < y[idx+1]
-    
+
     xv = x, y
     i, j = _2D.cell_index((px,py), xv)
     @test x[i] ≤ px < x[i+1]
-    @test y[j] ≤ py < y[j+1] 
+    @test y[j] ≤ py < y[j+1]
 end
 
 @testset "Passive markers 2D" begin

--- a/test/test_2D.jl
+++ b/test/test_2D.jl
@@ -81,8 +81,6 @@ vi_stream(x) =  π * 1e-5 * (x - 0.5)
     # test copy function
     particles_copy = copy(particles)
     pT_copy        = copy(pT)
-    @test particles_copy.index isa JustPIC.CellArrays.CPUCellArray
-    @test pT_copy              isa JustPIC.CellArrays.CPUCellArray
     @test particles_copy.index.data[:] == particles.index.data[:]
     @test pT_copy.data[:]              == pT.data[:]
 end

--- a/test/test_3D.jl
+++ b/test/test_3D.jl
@@ -78,6 +78,14 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
         @test pT_cpu              isa JustPIC.CellArrays.CPUCellArray
         @test particles_cpu.index.data[:] == Array(particles.index.data)[:]
         @test pT_cpu.data[:]              == Array(pT.data)[:]
+
+        # test copy function
+        particles_copy = copy(particles)
+        pT_copy        = copy(pT)
+        @test particles_copy.index isa JustPIC.CellArrays.CPUCellArray
+        @test pT_copy              isa JustPIC.CellArrays.CPUCellArray
+        @test particles_copy.index.data[:] == particles.index.data[:]
+        @test pT_copy.data[:]              == pT.data[:]
     end
 
     @testset "Particles initialization 3D" begin
@@ -126,7 +134,7 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
         particles = _3D.init_particles(
             backend, nxcell, max_xcell, min_xcell, xvi...
         )
-    
+
         arrays = _3D.SubgridDiffusionCellArrays(particles)
         # Test they are allocated in the right backend
         @test arrays.ΔT_subgrid isa TA(backend)

--- a/test/test_3D.jl
+++ b/test/test_3D.jl
@@ -82,8 +82,6 @@ vz_stream(x, z) = -250 * cos(π*x) * sin(π*z)
         # test copy function
         particles_copy = copy(particles)
         pT_copy        = copy(pT)
-        @test particles_copy.index isa JustPIC.CellArrays.CPUCellArray
-        @test pT_copy              isa JustPIC.CellArrays.CPUCellArray
         @test particles_copy.index.data[:] == particles.index.data[:]
         @test pT_copy.data[:]              == pT.data[:]
     end


### PR DESCRIPTION
Similar to the version of JustRelax. 
Usage: 
```julia
 particles = init_particle(
        backend, nxcell, max_xcell, min_xcell, xvi...
    )
particles_o = copy(particles)
```