### PR TITLE
Add type argurment to `Array`, `CuArray`, `ROCArray`  conversions

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -10,26 +10,34 @@ JustPIC.TA(::Type{AMDGPUBackend}) = ROCArray
 ROCCellArray(::Type{T}, ::UndefInitializer, dims::NTuple{N,Int}) where {T<:CellArrays.Cell,N} = CellArrays.CellArray{T,N,0,CUDA.ROCCellArrayArray{eltype(T),3}}(undef, dims)
 ROCCellArray(::Type{T}, ::UndefInitializer, dims::Int...) where {T<:CellArrays.Cell} = ROCCellArray(T, undef, dims)
 
-function AMDGPU.ROCArray(particles::JustPIC.Particles{JustPIC.AMDGPUBackend}) 
+function AMDGPU.ROCArray(::Type{T},particles::JustPIC.Particles) where {T<:Number}
     (; coords, index, nxcell, max_xcell, min_xcell, np) = particles
-    coords_gpu = ROCArray.(coords);
-    return Particles(CUDABackend, coords_gpu, ROCArray(index), nxcell, max_xcell, min_xcell, np)
+    coords_gpu = ntuple(i->ROCArray(T, coords[i]), Val(length(coords))) 
+    return Particles(CUDABackend, coords_gpu, ROCArray(T, index), nxcell, max_xcell, min_xcell, np)
 end
 
-function AMDGPU.ROCArray(phase_ratios::JustPIC.PhaseRatios{JustPIC.AMDGPUBackend}) 
+function AMDGPU.ROCArray(::Type{T}, phase_ratios::JustPIC.PhaseRatios) where {T<:Number}
     (; vertex, center) = phase_ratios
-    return JustPIC.PhaseRatios(CUDABackend, ROCArray(center), ROCArray(vertex))
+    return JustPIC.PhaseRatios(CUDABackend, ROCArray(T, center), ROCArray(T, vertex))
 end
 
 function AMDGPU.ROCArray(CA::CellArray) 
     ni     = size(CA)
     # Array initializations
-    Cell   = eltype(CA)
-    CA_ROC = ROCCellArray{Cell}(undef, ni...)
+    T_SArray = eltype(CA)
+    CA_ROC = ROCCellArray(SVector{length(T_SArray), T}, undef, ni...)
     # copy data to the ROC CellArray
     copyto!(CA_ROC.data, ROCArray(CA.data))
     return CA_ROC
 end
+
+JustPIC.AMDGPUBackend
+AMDGPU.ROCArray(particles::JustPIC.Particles{JustPIC.CPUBackend})         = AMDGPU.ROCArray(Float64, particles)
+AMDGPU.ROCArray(phase_ratios::JustPIC.PhaseRatios{JustPIC.CPUBackend})    = AMDGPU.ROCArray(Float64, phase_ratios)
+AMDGPU.ROCArray(particles::JustPIC.Particles{JustPIC.AMDGPUBackend})      = particles
+AMDGPU.ROCArray(phase_ratios::JustPIC.PhaseRatios{JustPIC.AMDGPUBackend}) = phase_ratios
+AMDGPU.ROCArray(CA::CellArray)                                            = AMDGPU.ROCArray(Float64, CA)
+
 
 module _2D
     using AMDGPU

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -8,25 +8,32 @@ JustPIC.TA(::Type{CUDABackend}) = CuArray
 CuCellArray(::Type{T}, ::UndefInitializer, dims::NTuple{N,Int}) where {T<:CellArrays.Cell,N} = CellArrays.CellArray{T,N,0,CUDA.CuArray{eltype(T),3}}(undef, dims)
 CuCellArray(::Type{T}, ::UndefInitializer, dims::Int...) where {T<:CellArrays.Cell} = CuCellArray(T, undef, dims)
 
-function CUDA.CuArray(particles::JustPIC.Particles{JustPIC.CPUBackend}) 
+function CUDA.CuArray(::Type{T},particles::JustPIC.Particles) where {T<:Number}
     (; coords, index, nxcell, max_xcell, min_xcell, np) = particles
-    coords_gpu = CuArray.(coords);
-    return Particles(CUDABackend, coords_gpu, CuArray(index), nxcell, max_xcell, min_xcell, np)
+    coords_gpu = ntuple(i->CuArray(T, coords[i]), Val(length(coords))) 
+    return Particles(CUDABackend, coords_gpu, CuArray(T, index), nxcell, max_xcell, min_xcell, np)
 end
 
-function CUDA.CuArray(phase_ratios::JustPIC.PhaseRatios{JustPIC.CPUBackend}) 
+function CUDA.CuArray(::Type{T}, phase_ratios::JustPIC.PhaseRatios) where {T<:Number}
     (; vertex, center) = phase_ratios
-    return JustPIC.PhaseRatios(CUDABackend, CuArray(center), CuArray(vertex))
+    return JustPIC.PhaseRatios(CUDABackend, CuArray(T, center), CuArray(T, vertex))
 end
 
-function CUDA.CuArray(CA::CellArray)
+function CUDA.CuArray(::Type{T}, CA::CellArray) where {T<:Number}
     ni      = size(CA)
     # Array initializations
-    CA_CUDA = CuCellArray(eltype(CA), undef, ni...)
+    T_SArray = eltype(CA)
+    CA_CUDA = CuCellArray(SVector{length(T_SArray), T}, undef, ni...)
     # copy data to the CUDA CellArray
     copyto!(CA_CUDA.data, CuArray(CA.data))
     return CA_CUDA
 end
+
+CUDA.CuArray(particles::JustPIC.Particles{JustPIC.CPUBackend})      = CUDA.CuArray(Float64, particles)
+CUDA.CuArray(phase_ratios::JustPIC.PhaseRatios{JustPIC.CPUBackend}) = CUDA.CuArray(Float64, phase_ratios)
+CUDA.CuArray(particles::JustPIC.Particles{CUDABackend})             = particles
+CUDA.CuArray(phase_ratios::JustPIC.PhaseRatios{CUDABackend})        = phase_ratios
+CUDA.CuArray(CA::CellArray)                                         = CUDA.CuArray(Float64, CA)
 
 module _2D
     using CUDA

--- a/test/test_save_load.jl
+++ b/test/test_save_load.jl
@@ -1,4 +1,8 @@
+using CUDA
 using JLD2, JustPIC, JustPIC._2D
+backend = CUDABackend
+# backend = JustPIC.CPUBackend
+using Test
 @testset "Save and load" begin
     # Initialize particles -------------------------------
     nxcell, max_xcell, min_xcell = 6, 6, 6
@@ -13,6 +17,17 @@ using JLD2, JustPIC, JustPIC._2D
     phases,      = init_cell_arrays(particles, Val(1));
     phase_ratios = PhaseRatios(backend, 2, ni);
 
+    # test type conversion
+    @test eltype(eltype(Array(phases)))                            === Float64
+    @test eltype(eltype(Array(Float64, phases)))                   === Float64
+    @test eltype(eltype(Array(Float32, phases)))                   === Float32
+    @test eltype(eltype(Array(particles).coords[1].data))          === Float64
+    @test eltype(eltype(Array(Float64, particles).coords[1].data)) === Float64
+    @test eltype(eltype(Array(Float32, particles).coords[1].data)) === Float32
+    @test eltype(eltype(Array(phase_ratios).vertex.data))          === Float64
+    @test eltype(eltype(Array(Float64, phase_ratios).vertex.data)) === Float64
+    @test eltype(eltype(Array(Float32, phase_ratios).vertex.data)) === Float32
+
     jldsave(
         "particles.jld2"; 
         particles    = Array(particles), 
@@ -25,37 +40,47 @@ using JLD2, JustPIC, JustPIC._2D
     phases2       = data["phases"]
     phase_ratios2 = data["phase_ratios"]
 
-    @test Array(particles.coords[1].data) == particles2.coords[1].data
-    @test Array(particles.coords[2].data) == particles2.coords[2].data
-    @test Array(particles.index.data)     == particles2.index.data
-    @test Array(phase_ratios.center.data) == phase_ratios2.center.data
-    @test Array(phase_ratios.vertex.data) == phase_ratios2.vertex.data
-    @test Array(phases.data)              == phases2.data
-    @test size(particles.coords[1].data)  == size(particles2.coords[1].data)
-    @test size(particles.coords[2].data)  == size(particles2.coords[2].data)
-    @test size(particles.index.data)      == size(particles2.index.data)
-    @test size(phase_ratios.center.data)  == size(phase_ratios2.center.data)
-    @test size(phase_ratios.vertex.data)  == size(phase_ratios2.vertex.data)
-    @test size(phases.data)               == size(phases2.data)
+    @test Array(particles).coords[1].data        == particles2.coords[1].data
+    @test Array(particles).coords[2].data        == particles2.coords[2].data
+    @test Array(particles).index.data            == particles2.index.data
+    @test Array(phase_ratios).center.data        == phase_ratios2.center.data
+    @test Array(phase_ratios).vertex.data        == phase_ratios2.vertex.data
+    @test Array(phases).data                     == phases2.data
+    @test size(Array(particles).coords[1].data)  == size(particles2.coords[1].data)
+    @test size(Array(particles).coords[2].data)  == size(particles2.coords[2].data)
+    @test size(Array(particles).index.data)      == size(particles2.index.data)
+    @test size(Array(phase_ratios).center.data)  == size(phase_ratios2.center.data)
+    @test size(Array(phase_ratios).vertex.data)  == size(phase_ratios2.vertex.data)
+    @test size(Array(phases).data)               == size(phases2.data)
 
-    if last(typeof(phases).parameters) <: CuArray
+    if isdefined(Main, :CUDA)
         particles_cuda    = CuArray(particles2)
         phase_ratios_cuda = CuArray(phase_ratios2)
         phases_cuda       = CuArray(phases2);
-        
+
         @test particles_cuda                       isa JustPIC.Particles{CUDABackend} 
         @test phase_ratios_cuda                    isa JustPIC.PhaseRatios{CUDABackend} 
         @test last(typeof(phases_cuda).parameters) <: CuArray{Float64, 3}
         @test typeof(phases_cuda)                  == typeof(phases)
+        @test size(particles_cuda.coords[1].data)  == size(particles.coords[1].data)
+        @test size(particles_cuda.coords[2].data)  == size(particles.coords[2].data)
+        @test size(particles_cuda.index.data)      == size(particles.index.data)
+        @test size(phase_ratios_cuda.center.data)  == size(phase_ratios.center.data)
+        @test size(phase_ratios_cuda.vertex.data)  == size(phase_ratios.vertex.data)
+        @test size(phases_cuda.data)               == size(phases.data)
 
-        @test size(particles_cuda.coords[1].data)  == size(particles2.coords[1].data)
-        @test size(particles_cuda.coords[2].data)  == size(particles2.coords[2].data)
-        @test size(particles_cuda.index.data)      == size(particles2.index.data)
-        @test size(phase_ratios_cuda.center.data)  == size(phase_ratios2.center.data)
-        @test size(phase_ratios_cuda.vertex.data)  == size(phase_ratios2.vertex.data)
-        @test size(phases_cuda.data)               == size(phases2.data)
+        # test type conversion
+        @test eltype(eltype(CuArray(phases)))                            === Float64
+        @test eltype(eltype(CuArray(Float64, phases)))                   === Float64
+        @test eltype(eltype(CuArray(Float32, phases)))                   === Float32
+        @test eltype(eltype(CuArray(particles).coords[1].data))          === Float64
+        @test eltype(eltype(CuArray(Float64, particles).coords[1].data)) === Float64
+        @test eltype(eltype(CuArray(Float32, particles).coords[1].data)) === Float32
+        @test eltype(eltype(CuArray(phase_ratios).vertex.data))          === Float64
+        @test eltype(eltype(CuArray(Float64, phase_ratios).vertex.data)) === Float64
+        @test eltype(eltype(CuArray(Float32, phase_ratios).vertex.data)) === Float32
 
-    elseif last(typeof(phases).parameters) <: ROCArray
+    elseif isdefined(Main, :AMDGPU)
         particles_amdgpu    = ROCArray(particles2)
         phase_ratios_amdgpu = ROCArray(phase_ratios2)
         phases_amdgpu       = ROCArray(phases2)
@@ -64,11 +89,24 @@ using JLD2, JustPIC, JustPIC._2D
         @test phase_ratios_amdgpu                    isa JustPIC.PhaseRatios{AMDGPUBackend} 
         @test last(typeof(phases_amdgpu).parameters) <: ROCArray{Float64, 3}
         @test typeof(phases_amdgpu)                  == typeof(phases)
-        @test size(particles_amdgpu.coords[1].data)  == size(particles2.coords[1].data)
-        @test size(particles_amdgpu.coords[2].data)  == size(particles2.coords[2].data)
-        @test size(particles_amdgpu.index.data)      == size(particles2.index.data)
-        @test size(phase_ratios_amdgpu.center.data)  == size(phase_ratios2.center.data)
-        @test size(phase_ratios_amdgpu.vertex.data)  == size(phase_ratios2.vertex.data)
-        @test size(phases_amdgpu.data)               == size(phases2.data)
+        @test size(particles_amdgpu.coords[1].data)  == size(particles.coords[1].data)
+        @test size(particles_amdgpu.coords[2].data)  == size(particles.coords[2].data)
+        @test size(particles_amdgpu.index.data)      == size(particles.index.data)
+        @test size(phase_ratios_amdgpu.center.data)  == size(phase_ratios.center.data)
+        @test size(phase_ratios_amdgpu.vertex.data)  == size(phase_ratios.vertex.data)
+        @test size(phases_amdgpu.data)               == size(phases.data)
+
+        # test type conversion
+        @test eltype(eltype(ROCArrayArray(phases)))                            === Float64
+        @test eltype(eltype(ROCArrayArray(Float64, phases)))                   === Float64
+        @test eltype(eltype(ROCArrayArray(Float32, phases)))                   === Float32
+        @test eltype(eltype(ROCArrayArray(particles).coords[1].data))          === Float64
+        @test eltype(eltype(ROCArrayArray(Float64, particles).coords[1].data)) === Float64
+        @test eltype(eltype(ROCArrayArray(Float32, particles).coords[1].data)) === Float32
+        @test eltype(eltype(ROCArrayArray(phase_ratios).vertex.data))          === Float64
+        @test eltype(eltype(ROCArrayArray(Float64, phase_ratios).vertex.data)) === Float64
+        @test eltype(eltype(ROCArrayArray(Float32, phase_ratios).vertex.data)) === Float32
     end
+    
+    rm("particles.jld2") # cleanup
 end


### PR DESCRIPTION
`CellArray`s and other `JustPIC` objects can be converted to other precissions, e.g. [@test eltype(eltype(Array(Float64, phases)))                   === Float64](https://github.com/JuliaGeodynamics/JustPIC.jl/blob/d903ea9865aee45e2202ec956879267a1423c96b/test/test_save_load.jl#L22)