### PR TITLE
Fix data races in injection kernels

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -179,8 +179,8 @@ module _2D
     end
 
     function JustPIC._2D.inject_particles_phase!(
-        particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid
-    )
+        particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid::NTuple{N}
+    ) where {N}
         inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
         return nothing
     end
@@ -439,8 +439,8 @@ module _3D
     end
 
     function JustPIC._3D.inject_particles_phase!(
-        particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid
-    )
+        particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid::NTuple{N}
+    ) where {N}
         inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
         return nothing
     end

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -156,10 +156,10 @@ module _2D
         return grid2particle!(Fp, xvi, F, particles)
     end
 
-    function JustPIC._2D.particle2grid_centroid!(
+    function JustPIC._2D.particle2centroid!(
         F::ROCArray, Fp, xi::NTuple, particles::Particles{AMDGPUBackend}
     )
-        return particle2grid_centroid!(F, Fp, xi, particles)
+        return particle2centroid!(F, Fp, xi, particles)
     end
 
     function JustPIC._2D.particle2grid!(
@@ -418,10 +418,10 @@ module _3D
         return grid2particle!(Fp, xvi, F, particles)
     end
 
-    function JustPIC._3D.particle2grid_centroid!(
+    function JustPIC._3D.particle2centroid!(
         F::ROCArray, Fp, xi::NTuple, particles::Particles{AMDGPUBackend}
     )
-        return particle2grid_centroid!(F, Fp, xi, particles)
+        return particle2centroid!(F, Fp, xi, particles)
     end
 
     function JustPIC._3D.particle2grid!(

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -174,7 +174,7 @@ module _2D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._2D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid)
+    function JustPIC._2D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid::NTuple{N}) where N
         return inject_particles!(particles, args, grid)
     end
 
@@ -434,7 +434,7 @@ module _3D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._3D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid)
+    function JustPIC._3D.inject_particles!(particles::Particles{AMDGPUBackend}, args, grid::NTuple{N}) where N
         return inject_particles!(particles, args, grid)
     end
 

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -171,7 +171,7 @@ module _2D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._2D.inject_particles!(particles::Particles{CUDABackend}, args, grid)
+    function JustPIC._2D.inject_particles!(particles::Particles{CUDABackend}, args, grid::NTuple{N}) where N
         return inject_particles!(particles, args, grid)
     end
 
@@ -431,7 +431,7 @@ module _3D
         return grid2particle_flip!(Fp, xvi, F, F0, particles; α=α)
     end
 
-    function JustPIC._3D.inject_particles!(particles::Particles{CUDABackend}, args, grid)
+    function JustPIC._3D.inject_particles!(particles::Particles{CUDABackend}, args, grid::NTuple{N}) where N
         return inject_particles!(particles, args, grid)
     end
 

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -157,10 +157,10 @@ module _2D
         return grid2particle!(Fp, xvi, F, particles)
     end
 
-    function JustPIC._2D.particle2grid_centroid!(
+    function JustPIC._2D.particle2centroid!(
         F::CuArray, Fp, xi::NTuple, particles::Particles{CUDABackend}
     )
-        return particle2grid_centroid!(F, Fp, xi, particles)
+        return particle2centroid!(F, Fp, xi, particles)
     end
 
     function JustPIC._2D.particle2grid!(F::CuArray, Fp, xi, particles)
@@ -415,10 +415,10 @@ module _3D
         return grid2particle!(Fp, xvi, F, particles)
     end
 
-    function JustPIC._3D.particle2grid_centroid!(
+    function JustPIC._3D.particle2centroid!(
         F::CuArray, Fp, xi::NTuple, particles::Particles{CUDABackend}
     )
-        return particle2grid_centroid!(F, Fp, xi, particles)
+        return particle2centroid!(F, Fp, xi, particles)
     end
 
     function JustPIC._3D.particle2grid!(

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -176,8 +176,8 @@ module _2D
     end
 
     function JustPIC._2D.inject_particles_phase!(
-        particles::Particles{CUDABackend}, particles_phases, args, fields, grid
-    )
+        particles::Particles{CUDABackend}, particles_phases, args, fields, grid::NTuple{N}
+    ) where {N}
         inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
         return nothing
     end
@@ -436,8 +436,8 @@ module _3D
     end
 
     function JustPIC._3D.inject_particles_phase!(
-        particles::Particles{CUDABackend}, particles_phases, args, fields, grid
-    )
+        particles::Particles{CUDABackend}, particles_phases, args, fields, grid::NTuple{N}
+    ) where N
         inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
         return nothing
     end

--- a/src/Interpolations/centroid_to_particle.jl
+++ b/src/Interpolations/centroid_to_particle.jl
@@ -182,8 +182,7 @@ end
     F::AbstractArray{T,2}, idx::NTuple{2,Integer}
 ) where {T}
     ni = nx, ny = size(F)
-    idx2 = @inline ntuple(i -> clamp(idx[i], 1, ni[i]), Val(2))
-    i, j = idx2
+    i, j   = @inline ntuple(i -> clamp(idx[i], 1, ni[i]), Val(2))
     i1, j1 = clamp(i + 1, 1, nx), clamp(j + 1, 1, ny)
     # optimal order for memory access
     F00 = F[i, j]
@@ -222,7 +221,7 @@ end
         Base.@_inline_meta
         j = idx[i]
         xc = if j < 1 # set cellcenter coordinates outside the domain otherwise
-            -di[i] * 0.5
+            xi[i][1] - di[i]
         else
             xi[i][j]
         end

--- a/src/Interpolations/particle_to_grid_centroid.jl
+++ b/src/Interpolations/particle_to_grid_centroid.jl
@@ -1,24 +1,24 @@
 ## LAUNCHERS
 
-function particle2grid_centroid!(F, Fp, xi::NTuple, particles::Particles)
+function particle2grid_centroid!(F, Fp, xci::NTuple, particles::Particles)
     (; coords) = particles
-    dxi = grid_size(xi)
-    @parallel (@idx size(coords[1])) _particle2grid_centroid!(F, Fp, xi, coords, dxi)
+    dxi = grid_size(xci)
+    @parallel (@idx size(coords[1])) _particle2grid_centroid!(F, Fp, xci, coords, dxi)
     return nothing
 end
 
-@parallel_indices (I...) function _particle2grid_centroid!(F, Fp, xi, coords, di)
-    _particle2grid_centroid!(F, Fp, I..., xi, coords, di)
+@parallel_indices (I...) function _particle2grid_centroid!(F, Fp, xci, coords, di)
+    _particle2grid_centroid!(F, Fp, I..., xci, coords, di)
     return nothing
 end
 
 ## INTERPOLATION KERNEL 2D
 
 @inbounds function _particle2grid_centroid!(
-    F, Fp, inode, jnode, xi::NTuple{2,T}, p, di
+    F, Fp, inode, jnode, xci::NTuple{2,T}, p, di
 ) where {T}
     px, py = p # particle coordinates
-    xvertex = xi[1][inode], xi[2][jnode] # centroid coordinates
+    xcenter = xci[1][inode], xci[2][jnode] # centroid coordinates
     ω, ωxF = 0.0, 0.0 # init weights
 
     # iterate over cell
@@ -26,19 +26,21 @@ end
         p_i = @index(px[i, inode, jnode]), @index(py[i, inode, jnode])
         # ignore lines below for unused allocations
         any(isnan, p_i) && continue
-        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω_i = bilinear_weight(xcenter, p_i, di)
+        # ω_i = distance_weight(xcenter, p_i; order=4)
         ω += ω_i
-        ωxF += ω_i * @index(Fp[i, inode, jnode])
+        # ωxF += ω_i * @index(Fp[i, inode, jnode])
+        ωxF = muladd(ω_i, @index(Fp[i, inode, jnode]), ωxF)
     end
 
     return F[inode, jnode] = ωxF / ω
 end
 
 @inbounds function _particle2grid_centroid!(
-    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, xi::NTuple{2,T3}, p, di
+    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, xci::NTuple{2,T3}, p, di
 ) where {N,T1,T2,T3}
     px, py = p # particle coordinates
-    xvertex = xi[1][inode], xi[2][jnode] # centroid coordinates
+    xcenter = xci[1][inode], xci[2][jnode] # centroid coordinates
     ω, ωxF = 0.0, 0.0 # init weights
 
     # iterate over cell
@@ -46,7 +48,9 @@ end
         p_i = @index(px[i, inode, jnode]), @index(py[i, inode, jnode])
         # ignore lines below for unused allocations
         any(isnan, p_i) && continue
-        ω_i = bilinear_weight(xvertex, p_i, di)
+        # ω_i = bilinear_weight(xcenter, p_i, di)
+        ω_i = distance_weight(xcenter, p_i; order=1)
+
         ω += ω_i
         ωxF = ntuple(Val(N)) do j
             Base.@_inline_meta
@@ -64,10 +68,10 @@ end
 ## INTERPOLATION KERNEL 3D
 
 @inbounds function _particle2grid_centroid!(
-    F, Fp, inode, jnode, knode, xi::NTuple{3,T}, p, di
+    F, Fp, inode, jnode, knode, xci::NTuple{3,T}, p, di
 ) where {T}
     px, py, pz = p # particle coordinates
-    xvertex = xi[1][inode], xi[2][jnode], xi[3][knode] # centroid coordinates
+    xcenter = xci[1][inode], xci[2][jnode], xci[3][knode] # centroid coordinates
     ω, ωF = 0.0, 0.0 # init weights
 
     # iterate over cell
@@ -78,7 +82,7 @@ end
             @index(pz[ip, inode, jnode, knode]),
         )
         isnan(p_i[1]) && continue  # ignore lines below for unused allocations
-        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω_i = bilinear_weight(xcenter, p_i, di)
         ω += ω_i
         ωF = muladd(ω_i, @index(Fp[ip, inode, jnode, knode]), ωF)
     end
@@ -87,10 +91,10 @@ end
 end
 
 @inbounds function _particle2grid_centroid!(
-    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, knode, xi::NTuple{3,T3}, p, di
+    F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, knode, xci::NTuple{3,T3}, p, di
 ) where {N,T1,T2,T3}
     px, py, pz = p # particle coordinates
-    xvertex = xi[1][inode], xi[2][jnode], xi[3][knode] # centroid coordinates
+    xcenter = xci[1][inode], xci[2][jnode], xci[3][knode] # centroid coordinates
     ω = 0.0 # init weights
     ωxF = ntuple(i -> 0.0, Val(N)) # init weights
 
@@ -102,7 +106,7 @@ end
             @index(pz[ip, inode, jnode, knode]),
         )
         any(isnan, p_i) && continue  # ignore lines below for unused allocations
-        ω_i = bilinear_weight(xvertex, p_i, di)
+        ω_i = bilinear_weight(xcenter, p_i, di)
         ω += ω_i
         ωxF = ntuple(Val(N)) do j
             Base.@_inline_meta

--- a/src/Interpolations/particle_to_grid_centroid.jl
+++ b/src/Interpolations/particle_to_grid_centroid.jl
@@ -1,20 +1,20 @@
 ## LAUNCHERS
 
-function particle2grid_centroid!(F, Fp, xci::NTuple, particles::Particles)
+function particle2centroid!(F, Fp, xci::NTuple, particles::Particles)
     (; coords) = particles
     dxi = grid_size(xci)
-    @parallel (@idx size(coords[1])) _particle2grid_centroid!(F, Fp, xci, coords, dxi)
+    @parallel (@idx size(coords[1])) _particle2centroid!(F, Fp, xci, coords, dxi)
     return nothing
 end
 
-@parallel_indices (I...) function _particle2grid_centroid!(F, Fp, xci, coords, di)
-    _particle2grid_centroid!(F, Fp, I..., xci, coords, di)
+@parallel_indices (I...) function _particle2centroid!(F, Fp, xci, coords, di)
+    _particle2centroid!(F, Fp, I..., xci, coords, di)
     return nothing
 end
 
 ## INTERPOLATION KERNEL 2D
 
-@inbounds function _particle2grid_centroid!(
+@inbounds function _particle2centroid!(
     F, Fp, inode, jnode, xci::NTuple{2,T}, p, di
 ) where {T}
     px, py = p # particle coordinates
@@ -36,7 +36,7 @@ end
     return F[inode, jnode] = ωxF / ω
 end
 
-@inbounds function _particle2grid_centroid!(
+@inbounds function _particle2centroid!(
     F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, xci::NTuple{2,T3}, p, di
 ) where {N,T1,T2,T3}
     px, py = p # particle coordinates
@@ -67,7 +67,7 @@ end
 
 ## INTERPOLATION KERNEL 3D
 
-@inbounds function _particle2grid_centroid!(
+@inbounds function _particle2centroid!(
     F, Fp, inode, jnode, knode, xci::NTuple{3,T}, p, di
 ) where {T}
     px, py, pz = p # particle coordinates
@@ -90,7 +90,7 @@ end
     return F[inode, jnode, knode] = ωF * inv(ω)
 end
 
-@inbounds function _particle2grid_centroid!(
+@inbounds function _particle2centroid!(
     F::NTuple{N,T1}, Fp::NTuple{N,T2}, inode, jnode, knode, xci::NTuple{3,T3}, p, di
 ) where {N,T1,T2,T3}
     px, py, pz = p # particle coordinates

--- a/src/Particles/injection.jl
+++ b/src/Particles/injection.jl
@@ -81,27 +81,47 @@ end
 
 # Injection of particles when multiple phases are present
 
-function inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
+function inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid::NTuple{N}) where N
     # unpack
     (; coords, index, min_xcell) = particles
     # linear to cartesian object
     ni = size(index)
     di = compute_dx(grid)
+    n_color = ntuple(i -> ceil(Int, ni[i] * 0.5), Val(N))
 
-    @parallel (@idx ni) inject_particles_phase!(
-        particles_phases, args, fields, coords, index, grid, di, min_xcell
-    )
+    if N == 2
+        for offsetᵢ in 1:3, offsetⱼ in 1:3        
+            @parallel (@idx ni) inject_particles_phase!(
+                particles_phases, args, fields, coords, index, grid, di, min_xcell, (offsetᵢ, offsetⱼ)
+            )            
+        end
+    elseif N == 3
+        for offsetᵢ in 1:3, offsetⱼ in 1:3, offsetₖ in 1:3
+            @parallel (@idx ni) inject_particles_phase!(
+                particles_phases, args, fields, coords, index, grid, di, min_xcell, (offsetᵢ, offsetⱼ, offsetₖ)
+            )
+        end
+    else
+        error(ThrowArgument("The dimension of the problem must be either 2 or 3"))
+    end
+
 end
 
 @parallel_indices (I...) function inject_particles_phase!(
-    particles_phases, args, fields, coords, index, grid, di, min_xcell
-)
-    if mapreduce(x -> x[1] ≤ x[2], &, zip(I, size(index))) &&
-        isemptycell(index, min_xcell, I...)
-        _inject_particles_phase!(
-            particles_phases, args, fields, coords, index, grid, di, min_xcell, I
-        )
+    particles_phases, args, fields, coords, index, grid, di, min_xcell, offsets::NTuple{N}
+) where N
+
+    indices = ntuple(Val(N)) do i
+        3 * (I[i] - 1) + offsets[i]
     end
+
+    if mapreduce(x -> x[1] ≤ x[2], &, zip(indices, size(index))) &&
+        isemptycell(index, min_xcell, indices...)
+        _inject_particles_phase!(
+            particles_phases, args, fields, coords, index, grid, di, min_xcell, indices
+        )    
+    end
+   
     return nothing
 end
 
@@ -152,7 +172,7 @@ function _inject_particles_phase!(
     return nothing
 end
 
-@inline distance2(x, y) = sqrt(mapreduce(x -> (x[1] - x[2])^2, +, zip(x, y)))
+@inline distance2(x, y) = √(mapreduce(x -> (x[1] - x[2])^2, +, zip(x, y)))
 
 # find index of the closest particle w.r.t the new particle
 function index_min_distance(coords, pn, index, current_cell, icell, jcell)
@@ -161,8 +181,7 @@ function index_min_distance(coords, pn, index, current_cell, icell, jcell)
     px, py = coords
     nx, ny = size(px)
 
-    for j in (jcell):(jcell), i in (icell):(icell), ip in cellaxes(index)
-        # for j in (jcell - 1):(jcell + 1), i in (icell - 1):(icell + 1), ip in cellaxes(index)
+    for j in (jcell - 1):(jcell + 1), i in (icell - 1):(icell + 1), ip in cellaxes(index)
 
         # early escape conditions
         ((i < 1) || (j < 1)) && continue # out of the domain
@@ -176,18 +195,13 @@ function index_min_distance(coords, pn, index, current_cell, icell, jcell)
         any(isnan, pxi) && continue
 
         d = distance(pxi, pn)
-        # if isnan(d) 
-        #     @show @index(index[ip, i, j]), pxi, d
-        # end
 
         if d < dist_min
             particle_idx_min = ip
             i_min, j_min = i, j
             dist_min = d
         end
-        # if isnan(d) 
-        #     @show @index(index[ip, i, j]), pxi, d, dist_min
-        # end
+
     end
 
     return particle_idx_min, (i_min, j_min)

--- a/src/Particles/injection.jl
+++ b/src/Particles/injection.jl
@@ -54,7 +54,15 @@ function _inject_particles!(
             # add phase to new particle
             particle_idx, min_idx = index_min_distance(coords, p_new, index, i, idx_cell...)
             for j in 1:N
-                @index args[j][i, idx_cell...] = @index args[j][particle_idx, min_idx...]
+                new_value = @index args[j][particle_idx, min_idx...]
+                # px_copy = @index coords[1][particle_idx, min_idx...]
+                # py_copy = @index coords[2][particle_idx, min_idx...]
+                # index_copy = @index index[particle_idx, min_idx...]
+
+                # if isnan(new_value)
+                #     @show particle_idx, min_idx, px_copy, py_copy
+                # end
+                @index args[j][i, idx_cell...] = new_value
             end
         end
         particles_num == min_xcell && break
@@ -145,7 +153,8 @@ function index_min_distance(coords, pn, index, current_cell, icell, jcell)
     px, py = coords
     nx, ny = size(px)
 
-    for j in (jcell - 1):(jcell + 1), i in (icell - 1):(icell + 1), ip in cellaxes(index)
+    for j in (jcell):(jcell), i in (icell):(icell), ip in cellaxes(index)
+        # for j in (jcell - 1):(jcell + 1), i in (icell - 1):(icell + 1), ip in cellaxes(index)
 
         # early escape conditions
         ((i < 1) || (j < 1)) && continue # out of the domain
@@ -155,13 +164,22 @@ function index_min_distance(coords, pn, index, current_cell, icell, jcell)
 
         # distance from new point to the existing particle
         pxi = @index(px[ip, i, j]), @index(py[ip, i, j])
+
+        any(isnan, pxi) && continue
+
         d = distance(pxi, pn)
+        # if isnan(d) 
+        #     @show @index(index[ip, i, j]), pxi, d
+        # end
 
         if d < dist_min
             particle_idx_min = ip
             i_min, j_min = i, j
             dist_min = d
         end
+        # if isnan(d) 
+        #     @show @index(index[ip, i, j]), pxi, d, dist_min
+        # end
     end
 
     return particle_idx_min, (i_min, j_min)

--- a/src/Particles/injection.jl
+++ b/src/Particles/injection.jl
@@ -10,22 +10,37 @@ Injects particles if the number of particles in a given cell is such that `n < p
 - `args`: `CellArrays`s containing particle fields.
 - `grid`: The grid cell vertices.
 """
-function inject_particles!(particles::Particles, args, grid)
+function inject_particles!(particles::Particles, args, grid::NTuple{N}) where N
     # function implementation goes here
     # unpack
     (; coords, index, min_xcell) = particles
     ni = size(index)
     di = compute_dx(grid)
+    n_color = ntuple(i -> ceil(Int, ni[i] * 0.5), Val(N))
 
-    @parallel (@idx ni) inject_particles!(args, coords, index, grid, di, min_xcell)
+    if N == 2
+        for offsetᵢ in 1:3, offsetⱼ in 1:3        
+            @parallel (@idx n_color) inject_particles!(args, coords, index, grid, di, min_xcell, (offsetᵢ, offsetⱼ))
+        end
+    elseif N == 3
+        for offsetᵢ in 1:3, offsetⱼ in 1:3, offsetₖ in 1:3
+            @parallel (@idx n_color) inject_particles!(args, coords, index, grid, di, min_xcell, (offsetᵢ, offsetⱼ, offsetₖ))
+        end
+    else
+        error(ThrowArgument("The dimension of the problem must be either 2 or 3"))
+    end
 end
 
 @parallel_indices (I...) function inject_particles!(
-    args, coords, index, grid, di, min_xcell
-)
-    if mapreduce(x -> x[1] ≤ x[2], &, zip(I, size(index))) &&
-        isemptycell(index, min_xcell, I...)
-        _inject_particles!(args, coords, index, grid, di, min_xcell, I)
+    args, coords, index, grid, di, min_xcell, offsets::NTuple{N}
+) where N
+    indices = ntuple(Val(N)) do i
+        3 * (I[i] - 1) + offsets[i]
+    end
+
+    if mapreduce(x -> x[1] ≤ x[2], &, zip(indices, size(index))) &&
+        isemptycell(index, min_xcell, indices...)
+        _inject_particles!(args, coords, index, grid, di, min_xcell, indices)
     end
     return nothing
 end
@@ -55,13 +70,6 @@ function _inject_particles!(
             particle_idx, min_idx = index_min_distance(coords, p_new, index, i, idx_cell...)
             for j in 1:N
                 new_value = @index args[j][particle_idx, min_idx...]
-                # px_copy = @index coords[1][particle_idx, min_idx...]
-                # py_copy = @index coords[2][particle_idx, min_idx...]
-                # index_copy = @index index[particle_idx, min_idx...]
-
-                # if isnan(new_value)
-                #     @show particle_idx, min_idx, px_copy, py_copy
-                # end
                 @index args[j][i, idx_cell...] = new_value
             end
         end

--- a/src/common.jl
+++ b/src/common.jl
@@ -18,7 +18,7 @@ include("Interpolations/particle_to_grid.jl")
 export particle2grid!
 
 include("Interpolations/particle_to_grid_centroid.jl")
-export particle2grid_centroid!
+export particle2centroid!
 
 include("Interpolations/grid_to_particle.jl")
 export grid2particle!, grid2particle_flip!


### PR DESCRIPTION
Includes breaking change, `particle2grid_centroid` is now called `particle2centroid`