### PR TITLE
Update TagBot.yml

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -15,4 +15,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
-          draft: true


### PR DESCRIPTION
update Talbot.yml so it releases the GH release itself doesn't put it as a draft, prevents over producing drafts (like in 0.5.2)