### PR TITLE
Reduce window size phase ratio calculation on the vertices

### DIFF
--- a/src/PhaseRatios/kernels.jl
+++ b/src/PhaseRatios/kernels.jl
@@ -67,10 +67,11 @@ end
         cell_index = i_cell, j_cell, k_cell
 
         for ip in cellaxes(phases)
-            p = @index(pxi[1][ip, cell_index...]),
-            @index(pxi[2][ip, cell_index...]),
-            @index(pxi[3][ip, cell_index...])
+            p = @index(pxi[1][ip, cell_index...]), @index(pxi[2][ip, cell_index...]), @index(pxi[3][ip, cell_index...])
             any(isnan, p) && continue
+            # check if it's within half cell
+            prod(x -> abs(x[1] - x[2]) ≥ x[3] / 2, zip(p, cell_vertex, di)) && continue
+
             x = @inline bilinear_weight(cell_vertex, p, di)
             ph_local = @index phases[ip, cell_index...]
             # this is doing sum(w * δij(i, phase)), where δij is the Kronecker delta
@@ -107,6 +108,8 @@ end
         for ip in cellaxes(phases)
             p = @index(pxi[1][ip, cell_index...]), @index(pxi[2][ip, cell_index...])
             any(isnan, p) && continue
+            # check if it's within half cell
+            prod(x -> abs(x[1] - x[2]) ≤ x[3] / 2, zip(p, cell_vertex, di)) && continue
             x = @inline bilinear_weight(cell_vertex, p, di)
             ph_local = @index phases[ip, cell_index...]
             # this is doing sum(w * δij(i, phase)), where δij is the Kronecker delta

--- a/test/test_2D.jl
+++ b/test/test_2D.jl
@@ -1,4 +1,3 @@
-
 @static if ENV["JULIA_JUSTPIC_BACKEND"] === "AMDGPU"
     using AMDGPU
     AMDGPU.allowscalar(true)
@@ -265,7 +264,7 @@ end
     end
  
     # Initialize particles -------------------------------
-    nxcell, max_xcell, min_xcell = 12, 24, 5
+    nxcell, max_xcell, min_xcell = 30, 40, 20
     particles = init_particles(
         backend, 
         nxcell, 


### PR DESCRIPTION
Previous window size was `dx*2`, it should be `dx`