### PR TITLE
Initialize PS inside __init__()

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -58,9 +58,11 @@ module _2D
     using MuladdMacro, ParallelStencil, CellArrays, CellArraysIndexing, StaticArrays
     using JustPIC
 
-    @init_parallel_stencil(AMDGPU, Float64, 2)
+    function __init__()
+        @init_parallel_stencil(AMDGPU, Float64, 2)
+        return nothing
+    end
     
-
     import JustPIC: Euler, RungeKutta2, AbstractAdvectionIntegrator
     import JustPIC._2D.CA
     import JustPIC: Particles, PassiveMarkers
@@ -324,8 +326,10 @@ module _3D
     using MuladdMacro, ParallelStencil, CellArrays, CellArraysIndexing, StaticArrays
     using JustPIC
 
-    @init_parallel_stencil(AMDGPU, Float64, 3)
-    
+    function __init__()
+        @init_parallel_stencil(AMDGPU, Float64, 3)
+        return nothing
+    end
 
     import JustPIC:
         Euler, RungeKutta2, AbstractAdvectionIntegrator, Particles, PassiveMarkers

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -56,9 +56,11 @@ module _2D
     using MuladdMacro, ParallelStencil, CellArrays, CellArraysIndexing, StaticArrays
     using JustPIC
 
-    @init_parallel_stencil(CUDA, Float64, 2)
+    function __init__()
+        @init_parallel_stencil(CUDA, Float64, 2)
+        return nothing
+    end
     
-
     import JustPIC: Euler, RungeKutta2, AbstractAdvectionIntegrator
     import JustPIC._2D.CA
     import JustPIC: Particles, PassiveMarkers
@@ -321,8 +323,10 @@ module _3D
     using MuladdMacro, ParallelStencil, CellArrays, CellArraysIndexing, StaticArrays
     using JustPIC
 
-    @init_parallel_stencil(CUDA, Float64, 3)
-    
+    function __init__()
+        @init_parallel_stencil(CUDA, Float64, 3)
+        return nothing
+    end
 
     macro myatomic(expr)
         return esc(

--- a/src/JustPIC_CPU.jl
+++ b/src/JustPIC_CPU.jl
@@ -9,7 +9,10 @@ using ..JustPIC
 
 import ..JustPIC: AbstractBackend, CPUBackend
 
-@init_parallel_stencil(Threads, Float64, 2)
+function __init__()
+    @init_parallel_stencil(Threads, Float64, 2)
+    return nothing
+end
 
 export CA
 
@@ -37,7 +40,10 @@ using ..JustPIC
 
 import ..JustPIC: AbstractBackend, CPUBackend
 
-@init_parallel_stencil(Threads, Float64, 3)
+function __init__()
+    @init_parallel_stencil(Threads, Float64, 3)
+    return nothing
+end
 
 export CA
 


### PR DESCRIPTION
Initializes ParallelStencil inside `__init__()` in each submodule. As suggested in [this issue](https://github.com/timholy/Revise.jl/issues/821)