### PR TITLE
Add `fill_chain!`

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -248,6 +248,10 @@ module _2D
         return MarkerChain(AMDGPUBackend, (px, py), index, xv, min_xcell, max_xcell)
     end
 
+    function JustPIC._2D.fill_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)
+        fill_chain!(chain, topo_x, topo_y)
+    end
+    
     function JustPIC._2D.advect_markerchain!(
         chain::MarkerChain{AMDGPUBackend},
         method::AbstractAdvectionIntegrator,

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -246,6 +246,10 @@ module _2D
         return MarkerChain(CUDABackend, (px, py), index, xv, min_xcell, max_xcell)
     end
 
+    function JustPIC._2D.fill_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)
+        fill_chain!(chain, topo_x, topo_y)
+    end
+
     function JustPIC._2D.advect_markerchain!(
         chain::MarkerChain{CUDABackend},
         method::AbstractAdvectionIntegrator,

--- a/src/common.jl
+++ b/src/common.jl
@@ -57,7 +57,7 @@ export check_injection, inject_particles!, inject_particles_phase!, clean_partic
 ## MARKER CHAIN RELATED FILES
 
 include("MarkerChain/init.jl")
-export init_markerchain
+export init_markerchain, fill_chain!
 
 include("MarkerChain/move.jl")
 export move_particles!


### PR DESCRIPTION
`fill_chain!` fills an existing marker chain with a given topographic profile. Example:

```julia
using CUDA
using JustPIC
using JustPIC._2D
using GLMakie

const backend = CUDABackend

# model geometry
n        = 51
nx       = n-1
Lx       = Ly = 1.0
# nodal vertices
xvi      = xv, yv = LinRange(0, Lx, n), LinRange(0, Ly, n)
# initialize the marker chain
nxcell, min_xcell, max_xcell = 12, 6, 24
initial_elevation = Ly/2
chain             = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation);
# create topographic profile
x = LinRange(0, 1, 200)
topo_x = TA(backend)(LinRange(0, 1, 200))
topo_y = TA(backend)(sin.(2π*topo_x) .* 0.1)
# fill the chain with the topographic profile` 
fill_chain!(chain, topo_x, topo_y)
# plot the chain
x_chain = Array(chain.coords[1].data[:])
y_chain = Array(chain.coords[2].data[:])
perms = sortperm(x_chain)
scatterlines(x_chain[perms], y_chain[perms], color=:black)
```

<img width="452" alt="image" src="https://github.com/user-attachments/assets/7dafae07-62e0-4bbd-b301-8bf83241be04">
