### PR TITLE
New marker chain functionalities

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -257,8 +257,8 @@ module _2D
         return nothing
     end
     
-    function JustPIC._2D.reconstruct_topography_from_vertices!(chain::MarkerChain{AMDGPUBackend})
-        reconstruct_topography_from_vertices!(chain)
+    function JustPIC._2D.reconstruct_chain_from_vertices!(chain::MarkerChain{AMDGPUBackend})
+        reconstruct_chain_from_vertices!(chain)
         return nothing
     end
 

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -235,17 +235,7 @@ module _2D
     ## MakerChain
 
     function JustPIC._2D.init_markerchain(::Type{AMDGPUBackend}, nxcell, min_xcell, max_xcell, xv, initial_elevation)
-        nx = length(xv) - 1
-        dx = xv[2] - xv[1]
-        dx_chain = dx / (nxcell + 1)
-        px, py = ntuple(_ -> @fill(NaN, (nx,), celldims = (max_xcell,)), Val(2))
-        index = @fill(false, (nx,), celldims = (max_xcell,), eltype = Bool)
-    
-        @parallel (1:nx) fill_markerchain_coords_index!(
-            px, py, index, xv, initial_elevation, dx_chain, nxcell, max_xcell
-        )
-    
-        return MarkerChain(AMDGPUBackend, (px, py), index, xv, min_xcell, max_xcell)
+        return init_markerchain(CUDABackend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
     end
 
     function JustPIC._2D.fill_chain_from_chain!(chain::MarkerChain{AMDGPUBackend}, topo_x, topo_y)

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -248,10 +248,25 @@ module _2D
         return MarkerChain(AMDGPUBackend, (px, py), index, xv, min_xcell, max_xcell)
     end
 
-    function JustPIC._2D.fill_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)
-        fill_chain!(chain, topo_x, topo_y)
+    function JustPIC._2D.fill_chain_from_chain!(chain::MarkerChain{AMDGPUBackend}, topo_x, topo_y)
+        fill_chain_from_chain!(chain, topo_x, topo_y)
     end
     
+    function JustPIC._2D.compute_topography_vertex!(chain::MarkerChain{AMDGPUBackend})
+        compute_topography_vertex!(chain)
+        return nothing
+    end
+    
+    function JustPIC._2D.reconstruct_topography_from_vertices!(chain::MarkerChain{AMDGPUBackend})
+        reconstruct_topography_from_vertices!(chain)
+        return nothing
+    end
+
+    function JustPIC._2D.fill_chain_from_vertices!(chain::MarkerChain{AMDGPUBackend}, topo_y)
+        fill_chain_from_vertices!(chain::MarkerChain, topo_y)
+        return nothing
+    end
+
     function JustPIC._2D.advect_markerchain!(
         chain::MarkerChain{AMDGPUBackend},
         method::AbstractAdvectionIntegrator,

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -246,8 +246,24 @@ module _2D
         return MarkerChain(CUDABackend, (px, py), index, xv, min_xcell, max_xcell)
     end
 
-    function JustPIC._2D.fill_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)
-        fill_chain!(chain, topo_x, topo_y)
+    function JustPIC._2D.fill_chain_from_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)
+        fill_chain_from_chain!(chain, topo_x, topo_y)
+        return nothing
+    end
+
+    function JustPIC._2D.compute_topography_vertex!(chain::MarkerChain{CUDABackend})
+        compute_topography_vertex!(chain)
+        return nothing
+    end
+    
+    function JustPIC._2D.reconstruct_topography_from_vertices!(chain::MarkerChain{CUDABackend})
+        reconstruct_topography_from_vertices!(chain)
+        return nothing
+    end
+
+    function JustPIC._2D.fill_chain_from_vertices!(chain::MarkerChain{CUDABackend}, topo_y)
+        fill_chain_from_vertices!(chain::MarkerChain, topo_y)
+        return nothing
     end
 
     function JustPIC._2D.advect_markerchain!(

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -233,17 +233,7 @@ module _2D
     ## MakerChain
 
     function JustPIC._2D.init_markerchain(::Type{CUDABackend}, nxcell, min_xcell, max_xcell, xv, initial_elevation)
-        nx = length(xv) - 1
-        dx = xv[2] - xv[1]
-        dx_chain = dx / (nxcell + 1)
-        px, py = ntuple(_ -> @fill(NaN, (nx,), celldims = (max_xcell,)), Val(2))
-        index = @fill(false, (nx,), celldims = (max_xcell,), eltype = Bool)
-    
-        @parallel (1:nx) fill_markerchain_coords_index!(
-            px, py, index, xv, initial_elevation, dx_chain, nxcell, max_xcell
-        )
-    
-        return MarkerChain(CUDABackend, (px, py), index, xv, min_xcell, max_xcell)
+        return init_markerchain(CUDABackend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
     end
 
     function JustPIC._2D.fill_chain_from_chain!(chain::MarkerChain{CUDABackend}, topo_x, topo_y)

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -256,8 +256,8 @@ module _2D
         return nothing
     end
     
-    function JustPIC._2D.reconstruct_topography_from_vertices!(chain::MarkerChain{CUDABackend})
-        reconstruct_topography_from_vertices!(chain)
+    function JustPIC._2D.reconstruct_chain_from_vertices!(chain::MarkerChain{CUDABackend})
+        reconstruct_chain_from_vertices!(chain)
         return nothing
     end
 

--- a/src/MarkerChain/Advection/advection.jl
+++ b/src/MarkerChain/Advection/advection.jl
@@ -5,6 +5,16 @@ function advect_markerchain!(
     advection!(chain, method, V, grid_vxi, dt)
     move_particles!(chain)
     resample!(chain)
+
+    # interpolate from markers to grid
+    compute_topography_vertex!(chain)
+    # average h_vertices0 and h_vertices and store in h_vertices
+    @. chain.h_vertices = (chain.h_vertices0 + chain.h_vertices) / 2
+    # reconstruct chain from vertices
+    reconstruct_chain_from_vertices!(chain)
+    # update old nodal topography
+    copyto!(chain.h_vertices0, chain.h_vertices)
+
     return nothing
 end
 

--- a/src/MarkerChain/Advection/advection.jl
+++ b/src/MarkerChain/Advection/advection.jl
@@ -104,7 +104,7 @@ end
 @inline function corner_field_nodes(F::AbstractArray{T,N}, pᵢ, xi_vx, dxi) where {T,N}
     I = ntuple(Val(N)) do i
         Base.@_inline_meta
-        cell_index(pᵢ[i], xi_vx[i], dxi[1])
+        cell_index(pᵢ[i], xi_vx[i], dxi[i])
     end
 
     # coordinates of lower-left corner of the cell

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -60,8 +60,10 @@ end
 function _reconstruct_h_from_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, ivertex)
     xcorner_left  = cell_vertices[ivertex]
     xcorner_right = cell_vertices[ivertex+1]
+    lx            =  xcorner_right - xcorner_left
     ycorner_left  = h_vertices[ivertex]
     ycorner_right = h_vertices[ivertex+1]
+    ly            =  ycorner_right - ycorner_left
 
     # count active particles
     np = 0
@@ -70,18 +72,19 @@ function _reconstruct_h_from_vertex_kernel!(h_vertices, chain_x, chain_y, cell_v
         np += 1
     end
 
-    # lazy linear interpolants
-    xp_new = LinRange(xcorner_left, xcorner_right, np+2)
-    xp_new = LinRange(xp_new[2], xp_new[end-1], np)
-    yp_new = LinRange(ycorner_left, ycorner_right, np+2)
-    yp_new = LinRange(yp_new[2], yp_new[end-1], np)
-
+    Δx     = lx / (np + 1)
+    Δy     = ly / (np + 1)
+    xp_new = xcorner_left
+    yp_new = ycorner_left
+    
     # fill cell arrays with new particle coordinates
     for ip in cellaxes(index)
         @index(index[ip, ivertex]) || break
 
-        @index chain_x[ip, ivertex] = xp_new[ip]
-        @index chain_y[ip, ivertex] = yp_new[ip]
+        xp_new += Δx
+        yp_new += Δy
+        @index chain_x[ip, ivertex] = xp_new
+        @index chain_y[ip, ivertex] = yp_new
     end
 
     return nothing

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -1,0 +1,89 @@
+function compute_topography_vertex!(chain::MarkerChain)
+    (; coords, index, cell_vertices, h_vertices) = chain;
+    chain_x, chain_y = coords;
+
+    _dx = inv(cell_vertices[2] - cell_vertices[1])
+
+    @parallel (1:length(cell_vertices)) _compute_h_vertex!(h_vertices, chain_x, chain_y, cell_vertices, index, _dx)
+    
+    return nothing
+end
+
+@parallel_indices (ivertex) function _compute_h_vertex!(h_vertices, chain_x, chain_y, cell_vertices, index, _dx)
+    _compute_h_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, _dx, ivertex)
+    return nothing
+end
+
+function _compute_h_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, _dx::T, ivertex) where T
+    h = zero(T)
+    ω = zero(T)
+    xcorner = cell_vertices[ivertex]
+
+    # iterate over cells on the left and right hand sides of the vertex
+    multiplier = -one(T)
+    for j in (ivertex-1):ivertex
+        if 0 < j < length(cell_vertices)
+            for ip in cellaxes(index)
+                @index(index[ip, j]) || break
+
+                x_m  = @index chain_x[ip, j]
+                y_m  = @index chain_y[ip, j]
+                dx_m = multiplier * (x_m - xcorner)
+                ωᵢ   = @muladd one(T) - dx_m * _dx
+                h   += y_m * ωᵢ
+                ω   += ωᵢ
+            end
+        end
+        multiplier = one(T)
+    end
+    h_vertices[ivertex] = h / ω
+
+    return nothing
+end
+
+######################################
+
+function reconstruct_topography_from_vertices!(chain::MarkerChain)
+    (; coords, index, cell_vertices, h_vertices) = chain;
+    chain_x, chain_y = coords;
+
+    @parallel (1:length(index)) _reconstruct_h_from_vertex!(h_vertices, chain_x, chain_y, cell_vertices, index)
+    
+    return nothing
+end
+
+@parallel_indices (ivertex) function _reconstruct_h_from_vertex!(h_vertices, chain_x, chain_y, cell_vertices, index)
+    _reconstruct_h_from_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, ivertex)
+    return nothing
+end
+
+function _reconstruct_h_from_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, ivertex)
+    xcorner_left = cell_vertices[ivertex]
+    xcorner_right = cell_vertices[ivertex+1]
+
+    ycorner_left = h_vertices[ivertex]
+    ycorner_right = h_vertices[ivertex+1]
+
+    # count active particles
+    np = 0
+    for ip in cellaxes(index)
+        @index(index[ip, ivertex]) || break
+        np += 1
+    end
+
+    # lazy linear interpolants
+    xp_new = LinRange(xcorner_left, xcorner_right, np+2)
+    xp_new = LinRange(xp_new[2], xp_new[end-1], np)
+    yp_new = LinRange(ycorner_left, ycorner_right, np+2)
+    yp_new = LinRange(yp_new[2], yp_new[end-1], np)
+
+    # fill cell arrays with new particle coordinates
+    for ip in cellaxes(index)
+        @index(index[ip, ivertex]) || break
+
+        @index chain_x[ip, ivertex] = xp_new[ip]
+        @index chain_y[ip, ivertex] = yp_new[ip]
+    end
+
+    return nothing
+end

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -43,7 +43,7 @@ end
 
 ######################################
 
-function reconstruct_topography_from_vertices!(chain::MarkerChain)
+function reconstruct_chain_from_vertices!(chain::MarkerChain)
     (; coords, index, cell_vertices, h_vertices) = chain;
     chain_x, chain_y = coords;
 
@@ -58,10 +58,9 @@ end
 end
 
 function _reconstruct_h_from_vertex_kernel!(h_vertices, chain_x, chain_y, cell_vertices, index, ivertex)
-    xcorner_left = cell_vertices[ivertex]
+    xcorner_left  = cell_vertices[ivertex]
     xcorner_right = cell_vertices[ivertex+1]
-
-    ycorner_left = h_vertices[ivertex]
+    ycorner_left  = h_vertices[ivertex]
     ycorner_right = h_vertices[ivertex+1]
 
     # count active particles

--- a/src/MarkerChain/init.jl
+++ b/src/MarkerChain/init.jl
@@ -9,7 +9,7 @@ function init_markerchain(::Type{backend}, nxcell, min_xcell, max_xcell, xv, ini
         px, py, index, xv, initial_elevation, dx_chain, nxcell, max_xcell
     )
     coords      = px, py
-    coords0     = copy(px), copy(py)
+    coords0     = px, py
     h_vertices  = @fill(initial_elevation, nx + 1)
     h_vertices0 = @fill(initial_elevation, nx + 1)
 

--- a/src/MarkerChain/init.jl
+++ b/src/MarkerChain/init.jl
@@ -1,4 +1,4 @@
-function init_markerchain(::Type{JustPIC.CPUBackend}, nxcell, min_xcell, max_xcell, xv, initial_elevation)
+function init_markerchain(::Type{backend}, nxcell, min_xcell, max_xcell, xv, initial_elevation) where {backend}
     nx = length(xv) - 1
     dx = xv[2] - xv[1]
     dx_chain = dx / (nxcell + 1)
@@ -13,7 +13,7 @@ function init_markerchain(::Type{JustPIC.CPUBackend}, nxcell, min_xcell, max_xce
     h_vertices  = @fill(initial_elevation, nx + 1)
     h_vertices0 = @fill(initial_elevation, nx + 1)
 
-    return MarkerChain(JustPIC.CPUBackend, coords, coords0, h_vertices, h_vertices0, xv, index, min_xcell, max_xcell)
+    return MarkerChain(backend, coords, coords0, h_vertices, h_vertices0, xv, index, min_xcell, max_xcell)
 end
 
 @parallel_indices (i) function fill_markerchain_coords_index!(
@@ -140,7 +140,7 @@ function fill_chain_from_vertices!(chain::MarkerChain, topo_y)
     copyto!(chain.h_vertices0, topo_y)
 
     # reconstruct marker chain
-    reconstruct_topography_from_vertices!(chain)
+    reconstruct_chain_from_vertices!(chain)
 
     # fill also the marker chain from the previous time step
     copyto!(chain.coords0[1].data, chain.coords[1].data)

--- a/src/MarkerChain/init.jl
+++ b/src/MarkerChain/init.jl
@@ -139,7 +139,7 @@ function fill_chain_from_vertices!(chain::MarkerChain, topo_y)
     copyto!(chain.h_vertices, topo_y)
     copyto!(chain.h_vertices0, topo_y)
 
-    # recontruct marker chain
+    # reconstruct marker chain
     reconstruct_topography_from_vertices!(chain)
 
     # fill also the marker chain from the previous time step

--- a/src/Particles/move_safe.jl
+++ b/src/Particles/move_safe.jl
@@ -19,7 +19,7 @@ function move_particles!(particles::AbstractParticles, grid::NTuple{N}, args) wh
     # make some space for incoming particles
     @parallel (@idx nxi) empty_particles!(coords, index, max_xcell, args)
     # move particles 
-    if N == 2
+    if N == 2 # 2D case
         nthreads = (16, 16)
         nblocks  = ceil.(Int, n_color ./ nthreads)
         for offsetᵢ in 1:3, offsetⱼ in 1:3
@@ -27,9 +27,8 @@ function move_particles!(particles::AbstractParticles, grid::NTuple{N}, args) wh
                 coords, grid, dxi, index, domain_limits, args, (offsetᵢ, offsetⱼ)
             )
         end
-    elseif N == 3
+    elseif N == 3 # 3D case 
         nthreads = (16, 16, 1)
-        # nthreads = (6, 6, 6)
         nblocks  = ceil.(Int, n_color ./ nthreads)
         for offsetᵢ in 1:3, offsetⱼ in 1:3, offsetₖ in 1:3
             @parallel (@idx n_color) nblocks nthreads move_particles_ps!(

--- a/src/common.jl
+++ b/src/common.jl
@@ -57,7 +57,10 @@ export check_injection, inject_particles!, inject_particles_phase!, clean_partic
 ## MARKER CHAIN RELATED FILES
 
 include("MarkerChain/init.jl")
-export init_markerchain, fill_chain!
+export init_markerchain, fill_chain_from_chain!, fill_chain_from_vertices!
+
+include("MarkerChain/bilinear_MC.jl")
+export reconstruct_topography_from_vertices!, compute_topography_vertex!
 
 include("MarkerChain/move.jl")
 export move_particles!

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -40,30 +40,35 @@ end
 function Particles(coords, index::CPUCellArray, nxcell, max_xcell, min_xcell, np)
     return Particles(CPUBackend, coords, index, nxcell, max_xcell, min_xcell, np)
 end
-
-struct MarkerChain{Backend,N,M,I,T1,T2,TV} <: AbstractParticles
-    coords::NTuple{N,T1}
-    index::T2
-    cell_vertices::TV # x-coord in 2D, (x,y)-coords in 3D
+struct MarkerChain{Backend,N,M,I,T1,T2,T3,TV} <: AbstractParticles
+    coords::NTuple{N,T1}    # current x-coord in 2D, (x,y)
+    coords0::NTuple{N,T1}   # x-coord in 2D, (x,y) from the previous time step
+    h_vertices::T2          # topography at the vertices of the grid (current)
+    h_vertices0::T2         # topography at the vertices of the grid (previous timestep)
+    cell_vertices::TV
+    index::T3
     max_xcell::I
     min_xcell::I
 
     function MarkerChain(
         backend,
         coords::NTuple{N,T1},
-        index::T2,
+        coords0::NTuple{N,T1},
+        h_vertices::T2,
+        h_vertices0::T2,
         cell_vertices::TV,
+        index::T3,
         min_xcell::I,
         max_xcell::I,
-    ) where {N,I,T1,T2,TV}
-        return new{backend,N,max_xcell,I,T1,T2,TV}(
-            coords, index, cell_vertices, max_xcell, min_xcell
+    ) where {N,I,T1,T2,T3,TV}
+        return new{backend,N,max_xcell,I,T1,T2,T3,TV}(
+            coords, coords0, h_vertices, h_vertices0, cell_vertices, index, max_xcell, min_xcell
         )
     end
 end
 
 function MarkerChain(coords, index::CPUCellArray, cell_vertices, min_xcell, max_xcell)
-    return MarkerChain(CPUBackend, coords, index, cell_vertices, min_xcell, max_xcell)
+    return MarkerChain(CPUBackend, coords, coords0, h_vertices, h_vertices0, cell_vertices, index, max_xcell, min_xcell)
 end
 
 struct PassiveMarkers{Backend,T} <: AbstractParticles


### PR DESCRIPTION
New functionalities:

* `fill_chain!` renamed to `fill_chain_from_chain` 

* Fill marker chain given a topography defined at the vertices of the grid:
```julia
fill_chain_from_vertices!(chain, topo_y)
```

* New `chain` fields `h_vertices` and `h_vertices0`. They contain the height of the marker chain interpolated onto the the vertices of the grid, of the current and previous time step, respectively.

* `compute_topography_vertex!(chain)` bilinear interpolation of the height from the marker chain onto `h_vertices`

* `reconstruct_chain_from_vertices!(chain)` linearly reconstructs the marker chain from `h_vertices` 
