### PR TITLE
Add `force_injection!`

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -7,11 +7,7 @@ on:
 
 permissions:
   contents: read
-
-  # needed for julia-actions/cache to delete old caches
   actions: write
-
-  # needed for googleapis/code-suggester
   pull-requests: write
 
 jobs:
@@ -19,11 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}
+          git fetch upstream
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
@@ -42,19 +44,19 @@ jobs:
       - name: Run Runic
         id: runic
         run: |
-            set +e
-            MERGE_BASE=$(git merge-base upstream/${{ github.base_ref }} HEAD) || exit 1
-            DIFF=$(git runic --diff $MERGE_BASE)
-            EXIT_CODE=$?
-  
-            echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-            echo "diff<<EOF" >> $GITHUB_OUTPUT
-            echo "$DIFF" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-  
-            # if Runic failed, bail out
-            [ $EXIT_CODE -eq 2 ] && exit 1 || exit 0
-  
+          set +e
+          MERGE_BASE=$(git merge-base upstream/${{ github.base_ref }} HEAD) || exit 1
+          DIFF=$(git runic --diff $MERGE_BASE)
+          EXIT_CODE=$?
+
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          echo "diff<<EOF" >> $GITHUB_OUTPUT
+          echo "$DIFF" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # if Runic failed, bail out
+          [ $EXIT_CODE -eq 2 ] && exit 1 || exit 0
+
       - name: Find comment
         uses: peter-evans/find-comment@v3
         id: find-comment
@@ -62,7 +64,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- runic-format-summary -->'
-  
+
       - name: Comment formatting suggestions
         if: steps.runic.outputs.exit_code == 1
         uses: peter-evans/create-or-update-comment@v4
@@ -81,10 +83,10 @@ jobs:
             ```diff
             ${{ steps.runic.outputs.diff }}
             ```
-  
-              </details>
-            edit-mode: replace
-  
+
+            </details>
+          edit-mode: replace
+
       - name: Update stale comment
         if: steps.runic.outputs.exit_code == 0 && steps.find-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
@@ -96,3 +98,8 @@ jobs:
 
             Your PR no longer requires formatting changes. Thank you for your contribution!
           edit-mode: replace
+
+      # XXX: if Github ever supports allow-failure (actions/runner#2347)
+      #- name: Propagate exit code
+      #  run: |
+      #    exit ${{ steps.runic.outputs.exit_code }}

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -304,6 +304,13 @@ module _2D
         return inject_particles!(particles, args, grid)
     end
 
+    function JustPIC._2D.force_injection!(particles::Particles{AMDGPUBackend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
+        force_injection!(particles, p_new, fields, values)
+        return nothing
+    end
+    
+    JustPIC._2D.force_injection!(particles::Particles{AMDGPUBackend}, p_new) = force_injection!(particles, p_new, (), ())
+
     function JustPIC._2D.inject_particles_phase!(
             particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid::NTuple{N}
         ) where {N}
@@ -674,6 +681,13 @@ module _3D
         return inject_particles!(particles, args, grid)
     end
 
+    function JustPIC._3D.force_injection!(particles::Particles{AMDGPUBackend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
+        force_injection!(particles, p_new, fields, values)
+        return nothing
+    end
+    
+    JustPIC._3D.force_injection!(particles::Particles{AMDGPUBackend}, p_new) = force_injection!(particles, p_new, (), ())
+    
     function JustPIC._3D.inject_particles_phase!(
             particles::Particles{AMDGPUBackend}, particles_phases, args, fields, grid::NTuple{N}
         ) where {N}

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -274,6 +274,13 @@ module _2D
         return inject_particles!(particles, args, grid)
     end
 
+    function JustPIC._2D.force_injection!(particles::Particles{CUDABackend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
+        force_injection!(particles, p_new, fields, values)
+        return nothing
+    end
+    
+    JustPIC._2D.force_injection!(particles::Particles{CUDABackend}, p_new) = force_injection!(particles, p_new, (), ())
+
     function JustPIC._2D.inject_particles_phase!(
             particles::Particles{CUDABackend}, particles_phases, args, fields, grid::NTuple{N}
         ) where {N}
@@ -643,6 +650,13 @@ module _3D
         inject_particles_phase!(particles::Particles, particles_phases, args, fields, grid)
         return nothing
     end
+
+    function JustPIC._3D.force_injection!(particles::Particles{CUDABackend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
+        force_injection!(particles, p_new, fields, values)
+        return nothing
+    end
+    
+    JustPIC._3D.force_injection!(particles::Particles{CUDABackend}, p_new) = force_injection!(particles, p_new, (), ())
 
     function JustPIC._3D.move_particles!(
             particles::Particles{CUDABackend}, grid::NTuple{N}, args

--- a/src/Particles/forced_injection.jl
+++ b/src/Particles/forced_injection.jl
@@ -35,23 +35,23 @@ force_injection!(particles::Particles{Backend}, p_new) where {Backend} = force_i
 @parallel_indices (I...) function force_injection!(coords::NTuple{2}, index, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
 
     # check whether there are new particles to inject in the ij-th cell
-    isnan(p_new[I..., begin]) && continue
-    
-    c = 0 # helper counter
-    # iterate over particles in the cell
-    for ip in cellaxes(index)
-        c += 1
-        c > cellnum(index) || doskip(index, ip, I...) && continue
-        pᵢ = p_new[I..., c]
-        @index coords[1][ip, I...] = pᵢ[1]
-        @index coords[2][ip, I...] = pᵢ[2]
-        @index index[ip, I...] = true
+    if !isnan(p_new[I..., begin])
+        c = 0 # helper counter
+        # iterate over particles in the cell
+        for ip in cellaxes(index)
+            c += 1
+            c > cellnum(index) || doskip(index, ip, I...) && continue
+            pᵢ = p_new[I..., c]
+            @index coords[1][ip, I...] = pᵢ[1]
+            @index coords[2][ip, I...] = pᵢ[2]
+            @index index[ip, I...] = true
 
-        # force fields to have a given value
-        for (value, field) in zip(values, fields)
-            @index field[ip, I...] = value
+            # force fields to have a given value
+            for (value, field) in zip(values, fields)
+                @index field[ip, I...] = value
+            end
         end
     end
-
+    
     return nothing
 end

--- a/src/Particles/forced_injection.jl
+++ b/src/Particles/forced_injection.jl
@@ -40,7 +40,8 @@ force_injection!(particles::Particles{Backend}, p_new) where {Backend} = force_i
         # iterate over particles in the cell
         for ip in cellaxes(index)
             c += 1
-            c > cellnum(index) || doskip(index, ip, I...) && continue
+            c > cellnum(index)  && continue
+            doskip(index, ip, I...) || continue
             pᵢ = p_new[I..., c]
             @index coords[1][ip, I...] = pᵢ[1]
             @index coords[2][ip, I...] = pᵢ[2]
@@ -52,6 +53,6 @@ force_injection!(particles::Particles{Backend}, p_new) where {Backend} = force_i
             end
         end
     end
-    
+
     return nothing
 end

--- a/src/Particles/forced_injection.jl
+++ b/src/Particles/forced_injection.jl
@@ -1,0 +1,57 @@
+
+"""
+    force_injection!(particles::Particles{Backend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {Backend, N}
+
+Forcefully injects new particles into the `particles` object. This function modifies the `particles` object in place.
+
+# Arguments
+- `particles::Particles{Backend}`: The particles object to be modified.
+- `p_new`: The new particles to be injected.
+- `fields::NTuple{N, Any}`: A tuple containing the fields to be updated.
+- `values::NTuple{N, Any}`: A tuple containing the values corresponding to the fields.
+
+# Returns
+- Nothing. This function modifies the `particles` object in place.
+"""
+function force_injection!(particles::Particles{Backend}, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {Backend, N}
+    (; coords, index) = particles;
+    ni = size(index)
+    @parallel (@idx ni) force_injection!(coords, index, p_new, fields, values)
+    return nothing
+end
+
+"""
+    force_injection!(particles::Particles{Backend}, p_new) where {Backend}
+
+Forces the injection of new particles into the existing `particles` collection. This function modifies the `particles` in place by adding the new particles specified in `p_new`.
+
+# Arguments
+- `particles::Particles{Backend}`: The existing collection of particles to which new particles will be added. The type of backend is specified by the `Backend` parameter.
+- `p_new`: The new particles to be injected into the existing collection.
+"""
+force_injection!(particles::Particles{Backend}, p_new) where {Backend} = force_injection!(particles, p_new, (), ())
+
+
+@parallel_indices (I...) function force_injection!(coords::NTuple{2}, index, p_new, fields::NTuple{N, Any}, values::NTuple{N, Any}) where {N}
+
+    # check whether there are new particles to inject in the ij-th cell
+    isnan(p_new[I..., begin]) && continue
+    
+    c = 0 # helper counter
+    # iterate over particles in the cell
+    for ip in cellaxes(index)
+        c += 1
+        c > cellnum(index) || doskip(index, ip, I...) && continue
+        pᵢ = p_new[I..., c]
+        @index coords[1][ip, I...] = pᵢ[1]
+        @index coords[2][ip, I...] = pᵢ[2]
+        @index index[ip, I...] = true
+
+        # force fields to have a given value
+        for (value, field) in zip(values, fields)
+            @index field[ip, I...] = value
+        end
+    end
+
+    return nothing
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -53,6 +53,9 @@ export advection!, advection_LinP!, advection_MQS!
 include("Particles/injection.jl")
 export check_injection, inject_particles!, inject_particles_phase!, clean_particles!
 
+include("Particles/forced_injection.jl")
+export force_injection!
+
 ## MARKER CHAIN RELATED FILES
 
 include("MarkerChain/init.jl")


### PR DESCRIPTION
This PR is addresses #186 and adds the function ``force_injection!` to inject a given set of new particles in a desired subset of cells. 

### Usage

* Define the new  `p_new` particles object. In the bi-dimensional case `p_new::Array{Union{Point{2, Float64}, SVector{2, Float64}} 3}`  is of size $nx \times ny \times np$ where $np$ is the number of new particles per given cell. Indices of `p_new` where there is no new particle must be `NaN`.

* **Use case (1)**  Inject only new particle coordinates:
```julia
force_injection!(particles::Particles, p_new)
```
 
* **Use case (2)**  Inject new particles and specific values for given fields defined at the particles. For example, if we want all new particles to have a brand new phase we can do as:

```julia
phases, = init_cell_arrays(particles, Val(1))
phases.data .= 1
phases.data[:, 16:end, :] .= 2

force_injection!(particles, p_new, (phases,), (3e0,))
```

