### PR TITLE
Fix bug that caused drifting when using  bilinear advection

### DIFF
--- a/scripts/temperature_advection3D.jl
+++ b/scripts/temperature_advection3D.jl
@@ -36,11 +36,11 @@ function main()
     ni = nx, ny, nz
     Li = Lx, Ly, Lz
     # nodal vertices
-    xvi = xv, yv, zv = ntuple(i -> range(0, Li[i], length = n), Val(3))
+    xvi = xv, yv, zv = ntuple(i -> LinRange(0, Li[i], n), Val(3))
     # grid spacing
     dxi = dx, dy, dz = ntuple(i -> xvi[i][2] - xvi[i][1], Val(3))
     # nodal centers
-    xci = xc, yc, zc = ntuple(i -> range(0 + dxi[i] / 2, Li[i] - dxi[i] / 2, length = ni[i]), Val(3))
+    xci = xc, yc, zc = ntuple(i -> LinRange(0 + dxi[i] / 2, Li[i] - dxi[i] / 2, ni[i]), Val(3))
 
     # staggered grid velocity nodal locations
     grid_vx = xv, expand_range(yc), expand_range(zc)
@@ -48,7 +48,7 @@ function main()
     grid_vz = expand_range(xc), expand_range(yc), zv
 
     # Initialize particles -------------------------------
-    nxcell, max_xcell, min_xcell = 125, 150, 100
+    nxcell, max_xcell, min_xcell = 25, 50, 10
     particles = init_particles(
         backend, nxcell, max_xcell, min_xcell, xvi...
     )
@@ -66,7 +66,7 @@ function main()
     particle_args = pT, = init_cell_arrays(particles, Val(1))
     grid2particle!(pT, xvi, T, particles)
 
-    niter = 10
+    niter = 100
     for _ in 1:niter
         advection!(particles, RungeKutta2(), V, (grid_vx, grid_vy, grid_vz), dt)
         move_particles!(particles, xvi, particle_args)

--- a/src/MarkerChain/areas0.jl
+++ b/src/MarkerChain/areas0.jl
@@ -1,0 +1,355 @@
+function compute_rock_fraction!(ratios, chain::MarkerChain, xvi, dxi)
+    compute_area_below_chain_centers!(ratios.center, chain, xvi, dxi)
+    compute_area_below_chain_vertex!(ratios.vertex, chain, xvi, dxi)
+    compute_area_below_chain_vx!(ratios.Vx, chain, xvi, dxi)
+    compute_area_below_chain_vy!(ratios.Vy, chain, xvi, dxi)
+    return nothing
+end
+
+function compute_area_below_chain_centers!(ratio_center, chain, xvi, dxi)
+    topo_x, topo_y = chain.cell_vertices, chain.h_vertices
+    nx, ny = size(ratio_center)
+    @parallel (1:nx, 1:ny) _compute_area_below_chain_center!(
+        ratio_center, topo_x, topo_y, xvi..., dxi
+    )
+    return nothing
+end
+
+@parallel_indices (i, j) function _compute_area_below_chain_center!(
+        ratio, topo_x, topo_y, xv, yv, dxi
+    )
+    _, dy = dxi
+
+    # cell min max coordinates
+    x_min_cell, x_max_cell = xv[i], xv[i + 1]
+    y_min_cell, y_max_cell = yv[j], yv[j + 1]
+    topo_xᵢ = topo_x[i], topo_x[i + 1]
+    topo_yᵢ = topo_y[i], topo_y[i + 1]
+
+    isbelow = topo_yᵢ[1] - y_min_cell ≥ dy && topo_yᵢ[2] - y_min_cell ≥ dy
+    isabove = y_max_cell - topo_yᵢ[1] ≥ dy && y_max_cell - topo_yᵢ[2] ≥ dy
+
+    if isbelow
+        ratio[i, j] = one(eltype(topo_xᵢ))
+
+    elseif isabove
+        ratio[i, j] = zero(eltype(topo_xᵢ))
+
+    else
+        # compute area at cell center
+        area_rock = compute_area_below_chain(
+            topo_xᵢ, topo_yᵢ, x_min_cell, x_max_cell, y_min_cell, y_max_cell, dxi
+        )
+        area_cell = prod(dxi)
+        ratio[i, j] = clamp(area_rock / area_cell, 0, 1)
+    end
+
+    return nothing
+end
+
+function compute_area_below_chain_vx!(ratio_velocity, chain, xvi, dxi)
+    topo_x, topo_y = chain.cell_vertices, chain.h_vertices
+    nx, ny = size(ratio_velocity)
+    masks_x = ((-0.5, 0.0), (0.0, 0.5))
+    masks_y = ((0.0, 1.0), (0.0, 1.0))
+    @parallel (1:nx, 1:ny) _compute_area_below_chain_vx!(
+        ratio_velocity, topo_x, topo_y, masks_x, masks_y, xvi..., nx, dxi
+    )
+    return nothing
+end
+
+@parallel_indices (i, j) function _compute_area_below_chain_vx!(
+        ratios, topo_x, topo_y, masks_x, masks_y, xv, yv, n, dxi
+    )
+    dx, dy = dxi
+    area_cell = prod(dxi) / 2
+    ratios[i, j] = zero(eltype(dx))
+    correction = 1
+    for (c, ii) in enumerate((i - 1):i)
+        if 0 < ii < n
+            if 1 < i < n
+                correction = 0.5
+            else
+                correction = 2.0e0
+            end
+            x_min_cell, x_max_cell = xv[i] .+ masks_x[c] .* dx
+            y_min_cell, y_max_cell = yv[j] .+ masks_y[c] .* dy
+
+            topo_xᵢ = topo_x[ii], topo_x[ii + 1]
+            topo_yᵢ = topo_y[ii], topo_y[ii + 1]
+            p1 = topo_xᵢ[1], topo_yᵢ[1]
+            p2 = topo_xᵢ[2], topo_yᵢ[2]
+
+            # recompute topography intersections
+            if do_intersect(p1, p2, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+                p1, p2 = get_intersections(
+                    (p1, p2), x_min_cell, x_max_cell, y_min_cell, y_max_cell
+                )
+                topo_xᵢ = p1[1], p1[2]
+                topo_xᵢ = p2[1], p2[2]
+            end
+
+            isbelow = topo_yᵢ[1] - y_min_cell ≥ dy && topo_yᵢ[2] - y_min_cell ≥ dy
+            isabove = y_max_cell - topo_yᵢ[1] ≥ dy && y_max_cell - topo_yᵢ[2] ≥ dy
+
+            if isbelow
+                ratios[i, j] = min(1, ratios[i, j] + 1)
+
+            elseif isabove
+                ratios[i, j] = zero(eltype(topo_xᵢ))
+
+            else
+                # compute area at cell center
+                area_rock = compute_area_below_chain(
+                    topo_xᵢ, topo_yᵢ, x_min_cell, x_max_cell, y_min_cell, y_max_cell, dxi
+                )
+                ratios[i, j] += clamp(correction * area_rock / area_cell, 0, 1)
+            end
+        end
+    end
+    return nothing
+end
+
+function compute_area_below_chain_vy!(ratio_velocity, chain, xvi, dxi)
+    topo_x, topo_y = chain.cell_vertices, chain.h_vertices
+    nx, ny = size(ratio_velocity)
+    masks_x = ((0.0, 1.0), (0.0, 1.0))
+    masks_y = ((-0.5, 0.0), (0.0, 0.5))
+    @parallel (1:nx, 1:ny) _compute_area_below_chain_vy!(
+        ratio_velocity, topo_x, topo_y, masks_x, masks_y, xvi..., ny, dxi
+    )
+    return nothing
+end
+
+@parallel_indices (i, j) function _compute_area_below_chain_vy!(
+        ratios, topo_x, topo_y, masks_x, masks_y, xv, yv, n, dxi
+    )
+    dx, dy = dxi
+    area_cell = prod(dxi) / 2
+    ratios[i, j] = zero(eltype(dx))
+    correction = 1
+    for (c, jj) in enumerate((j - 1):j)
+        if 0 < jj < n
+            if 1 < j < n
+                correction = 0.5
+            else
+                correction = 2.0e0
+            end
+            x_min_cell, x_max_cell = xv[i] .+ masks_x[c] .* dx
+            y_min_cell, y_max_cell = yv[jj] .+ masks_y[c] .* dy
+
+            topo_xᵢ = topo_x[i], topo_x[i + 1]
+            topo_yᵢ = topo_y[i], topo_y[i + 1]
+            p1 = topo_xᵢ[1], topo_yᵢ[1]
+            p2 = topo_xᵢ[2], topo_yᵢ[2]
+
+            # recompute topography intersections
+            if do_intersect(p1, p2, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+                p1, p2 = get_intersections(
+                    (p1, p2), x_min_cell, x_max_cell, y_min_cell, y_max_cell
+                )
+                topo_xᵢ = p1[1], p1[2]
+                topo_xᵢ = p2[1], p2[2]
+            end
+
+            isbelow = topo_yᵢ[1] - y_min_cell ≥ dy / 2 && topo_yᵢ[2] - y_min_cell ≥ dy / 2
+            isabove = y_max_cell - topo_yᵢ[1] ≥ dy / 2 && y_max_cell - topo_yᵢ[2] ≥ dy / 2
+
+            if isbelow
+                ratios[i, j] = min(1, ratios[i, j] + 1)
+
+            elseif isabove
+                ratios[i, j] = zero(eltype(topo_xᵢ))
+
+            else
+                # compute area at cell center
+                area_rock = compute_area_below_chain(
+                    topo_xᵢ, topo_yᵢ, x_min_cell, x_max_cell, y_min_cell, y_max_cell, dxi
+                )
+                ratios[i, j] += clamp(correction * area_rock / area_cell, 0, 1)
+            end
+        end
+    end
+    return nothing
+end
+
+function compute_area_below_chain_vertex!(ratio_vertex, chain, xvi, dxi)
+    topo_x, topo_y = chain.cell_vertices, chain.h_vertices
+    ni = size(ratio_vertex)
+    masks_x = ((-0.5, 0.0), (0.0, 0.5), (-0.5, 0.0), (0.0, 0.5))
+    masks_y = ((-0.5, 0.0), (-0.5, 0.0), (0.0, 0.5), (0.0, 0.5))
+    @parallel (@idx ni) _compute_area_below_chain_vertex!(
+        ratio_vertex, topo_x, topo_y, masks_x, masks_y, xvi..., ni..., dxi
+    )
+    return nothing
+end
+
+@parallel_indices (i, j) function _compute_area_below_chain_vertex!(
+        ratios, topo_x, topo_y, masks_x, masks_y, xv, yv, nx, ny, dxi
+    )
+    dx, dy = dxi
+    area_cell = prod(dxi) / 2
+    ratios[i, j] = zero(eltype(dx))
+    correction = 1
+    c = 0
+    for jj in (j - 1):j, ii in (i - 1):i
+        c += 1
+        if 0 < ii < nx && 0 < jj < ny
+            if 1 < i < nx && 1 < j < ny
+                correction = 0.5
+            else
+                correction = 2.0e0
+            end
+            x_min_cell, x_max_cell = xv[i] .+ masks_x[c] .* dx
+            y_min_cell, y_max_cell = yv[jj] .+ masks_y[c] .* dy
+
+            topo_xᵢ = topo_x[ii], topo_x[ii + 1]
+            topo_yᵢ = topo_y[ii], topo_y[ii + 1]
+            p1 = topo_xᵢ[1], topo_yᵢ[1]
+            p2 = topo_xᵢ[2], topo_yᵢ[2]
+
+            # recompute topography intersections
+            if do_intersect(p1, p2, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+                p1, p2 = get_intersections(
+                    (p1, p2), x_min_cell, x_max_cell, y_min_cell, y_max_cell
+                )
+                topo_xᵢ = p1[1], p1[2]
+                topo_yᵢ = p2[1], p2[2]
+            end
+
+            # isbelow = topo_yᵢ[1] - y_min_cell ≥ dy / 2 && topo_yᵢ[2] - y_min_cell ≥ dy / 2
+            # isabove = y_max_cell - topo_yᵢ[1] ≥ dy / 2 && y_max_cell - topo_yᵢ[2] ≥ dy / 2
+
+            # if isbelow
+            #     ratios[i, j] = min(1, ratios[i, j] + 1)
+
+            # # elseif isabove
+            # #     ratios[i, j] = zero(eltype(topo_xᵢ))
+
+            # else
+            # compute area at cell center
+            area_rock = compute_area_below_chain(
+                topo_xᵢ, topo_yᵢ, x_min_cell, x_max_cell, y_min_cell, y_max_cell, dxi
+            )
+            ratios[i, j] += clamp(correction * area_rock / area_cell, 0, 1)
+            # end
+            ratios[i, j] = clamp(ratios[i, j], 0, 1)
+        end
+    end
+    return nothing
+end
+
+#############################
+
+function compute_area_below_chain(
+        topo_xᵢ, topo_yᵢ, x_min_cell::T, x_max_cell::T, y_min_cell::T, y_max_cell::T, dxi
+    ) where {T <: Real}
+    dx, dy = dxi
+    area = zero(T)
+
+    is_chain_within_cell = true
+    for y in topo_yᵢ
+        is_chain_within_cell *= y_min_cell ≤ y ≤ y_max_cell
+    end
+
+    # whole topograpy segment is within the cell
+    # := trapezoid area
+    if is_chain_within_cell
+        area += trapezoid_area((topo_yᵢ .- y_min_cell)..., dx)
+
+    else
+        # coordinates of topography segment
+        p1 = topo_xᵢ[1], topo_yᵢ[1]
+        p2 = topo_xᵢ[2], topo_yᵢ[2]
+        p = p1, p2
+
+        # compute intersections between topography segment and cell boundaries
+        intersections = get_intersections(p, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+
+        # compute inner area
+        dx_intersections = intersections[2][1] - intersections[1][1]
+        area += trapezoid_area(
+            intersections[1][2] - y_min_cell,
+            intersections[2][2] - y_min_cell,
+            dx_intersections,
+        )
+
+        # compute area of the tails, if necessary
+        # compute left-hand-side tail
+        if intersections[1][2] ≥ y_max_cell
+            lx = intersections[1][1] - x_min_cell
+            area += rectangle_area(lx, dy)
+        end
+        # compute right-hand-side tail
+        if intersections[2][2] ≥ y_max_cell
+            lx = x_max_cell - intersections[1][1]
+            area += rectangle_area(lx, dy)
+        end
+    end
+
+    return area
+end
+
+### Utils
+
+@inline trapezoid_area(a, b, h) = (a + b) * h / 2
+@inline rectangle_area(lx, ly) = lx * ly
+
+function slope_intercept(p1, p2)
+    # unpack
+    x1, y1 = p1
+    x2, y2 = p2
+    # compute slope and intercept
+    slope = (y2 - y1) / (x2 - x1)
+    intercept = y1 - slope * x1
+
+    return slope, intercept
+end
+
+function line_intersection(p1, p2, q1, q2)
+    # compute slopes and intercepts
+    a, c = slope_intercept(p1, p2)
+    b, d = slope_intercept(q1, q2)
+    # compute intersection point
+    px = (isinf(a) || a == b) ? p1[1] : (d - c) / (a - b)
+    py = @muladd b * px + d
+    return (px, py)
+end
+
+function get_intersections(p::NTuple{2}, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+    p1, p2 = p
+    intersections = Base.@ntuple 2 ii -> begin
+        @inline
+        pᵢ = p[ii]
+        intersection = if pᵢ[2] > y_max_cell
+            line_intersection(p1, p2, (x_min_cell, y_max_cell), (x_max_cell, y_max_cell))
+        elseif pᵢ[2] < y_min_cell
+            line_intersection(p1, p2, (x_min_cell, y_min_cell), (x_max_cell, y_min_cell))
+        else
+            pᵢ
+        end
+    end
+    return intersections
+end
+
+function find_minmax_cell_indices(topo_yᵢ, origin_y, dy)
+    ymin, ymax = extrema(topo_yᵢ)
+    min_cell_j = Int((ymin - origin_y) ÷ dy) + 1
+    max_cell_j = Int((ymax - origin_y) ÷ dy) + 1
+    return min_cell_j, max_cell_j
+end
+
+# check if the topography segment intersects with the lateral cell boundaries;
+# if it does, it does intersect with the cell
+function do_intersect(p1, p2, x_min_cell, x_max_cell, y_min_cell, y_max_cell)
+    _, left_y = line_intersection(
+        p1, p2, (x_min_cell, y_min_cell), (x_min_cell, y_max_cell)
+    )
+    y_min_cell ≤ left_y ≤ y_max_cell && return true
+    _, right_y = line_intersection(
+        p1, p2, (x_max_cell, y_min_cell), (x_max_cell, y_max_cell)
+    )
+    y_min_cell ≤ right_y ≤ y_max_cell && return true
+
+    return false
+end

--- a/src/Particles/Advection/advection.jl
+++ b/src/Particles/Advection/advection.jl
@@ -82,11 +82,11 @@ end
 @inline function interp_velocity2particle(
         p_i::Union{SVector, NTuple}, grid::NTuple{2}, dxi::NTuple{2}, V::NTuple{2, AbstractArray}, idx
     )
-    i, j    = idx
+    i, j = idx
     xcorner = grid[1][1][i], grid[2][2][j]
-    Vx_grid = V[1][i, j+1], V[1][i+1, j+1]
-    Vy_grid = V[2][i+1, j], V[2][i+1, j+1]
-    ti      = normalize_coordinates(p_i, xcorner, dxi)
+    Vx_grid = V[1][i, j + 1], V[1][i + 1, j + 1]
+    Vy_grid = V[2][i + 1, j], V[2][i + 1, j + 1]
+    ti = normalize_coordinates(p_i, xcorner, dxi)
 
     Vx_interp = lerp(ti[1], Vx_grid...)
     Vy_interp = lerp(ti[2], Vy_grid...)
@@ -99,10 +99,10 @@ end
     )
     i, j, k = idx
     xcorner = grid[1][1][i], grid[2][2][j], grid[3][3][k]
-    Vx_grid = V[1][i, j+1, k+1], V[1][i+1, j+1, k+1]
-    Vy_grid = V[2][i+1, j, k+1], V[2][i+1, j+1, k+1]
-    Vz_grid = V[3][i+1, j+1, k], V[3][i+1, j+1, k+1]
-    ti      = normalize_coordinates(p_i, xcorner, dxi)
+    Vx_grid = V[1][i, j + 1, k + 1], V[1][i + 1, j + 1, k + 1]
+    Vy_grid = V[2][i + 1, j, k + 1], V[2][i + 1, j + 1, k + 1]
+    Vz_grid = V[3][i + 1, j + 1, k], V[3][i + 1, j + 1, k + 1]
+    ti = normalize_coordinates(p_i, xcorner, dxi)
 
     Vx_interp = lerp(ti[1], Vx_grid...)
     Vy_interp = lerp(ti[2], Vy_grid...)

--- a/src/Particles/Advection/advection0.jl
+++ b/src/Particles/Advection/advection0.jl
@@ -65,48 +65,73 @@ end
 
 @inline function interp_velocity2particle(
         particle_coords::NTuple{N, Any},
-        grid,
+        grid_vi,
         local_limits,
         dxi,
         V::NTuple{N, Any},
         idx::NTuple{N, Any},
     ) where {N}
-    v = interp_velocity2particle(particle_coords, grid, dxi, V, idx)
     return ntuple(Val(N)) do i
         Base.@_inline_meta
         local_lims = local_limits[i]
-        check_local_limits(local_lims, particle_coords) ? v[i] : Inf
+        v = if check_local_limits(local_lims, particle_coords)
+            interp_velocity2particle(particle_coords, grid_vi[i], dxi, V[i], idx)
+        else
+            Inf
+        end
     end
 end
 
+# Interpolate velocity from staggered grid to particle. Innermost kernel
 @inline function interp_velocity2particle(
-        p_i::Union{SVector, NTuple}, grid::NTuple{2}, dxi::NTuple{2}, V::NTuple{2, AbstractArray}, idx
+        p_i::Union{SVector, NTuple}, xi_vx::NTuple, dxi::NTuple, F::AbstractArray, idx
     )
-    i, j    = idx
-    xcorner = grid[1][1][i], grid[2][2][j]
-    Vx_grid = V[1][i, j+1], V[1][i+1, j+1]
-    Vy_grid = V[2][i+1, j], V[2][i+1, j+1]
-    ti      = normalize_coordinates(p_i, xcorner, dxi)
-
-    Vx_interp = lerp(ti[1], Vx_grid...)
-    Vy_interp = lerp(ti[2], Vy_grid...)
-
-    return Vx_interp, Vy_interp
+    # F and coordinates at/of the cell corners
+    Fi, xci = corner_field_nodes(F, p_i, xi_vx, dxi, idx)
+    # normalize particle coordinates
+    ti = normalize_coordinates(p_i, xci, dxi)
+    # Interpolate field F onto particle
+    Fp = lerp(Fi, ti)
+    # return interpolated field
+    return Fp
 end
 
-@inline function interp_velocity2particle(
-        p_i::Union{SVector, NTuple}, grid::NTuple{3}, dxi::NTuple{3}, V::NTuple{3, AbstractArray}, idx
-    )
-    i, j, k = idx
-    xcorner = grid[1][1][i], grid[2][2][j], grid[3][3][k]
-    Vx_grid = V[1][i, j+1, k+1], V[1][i+1, j+1, k+1]
-    Vy_grid = V[2][i+1, j, k+1], V[2][i+1, j+1, k+1]
-    Vz_grid = V[3][i+1, j+1, k], V[3][i+1, j+1, k+1]
-    ti      = normalize_coordinates(p_i, xcorner, dxi)
+## Other functions
 
-    Vx_interp = lerp(ti[1], Vx_grid...)
-    Vy_interp = lerp(ti[2], Vy_grid...)
-    Vz_interp = lerp(ti[3], Vz_grid...)
+@generated function corner_field_nodes(
+        F::AbstractArray{T, N},
+        particle,
+        xi_vx,
+        dxi,
+        idx::Union{SVector{N, Integer}, NTuple{N, Integer}},
+    ) where {N, T}
+    return quote
+        Base.@_inline_meta
+        begin
+            Base.@nexprs $N i -> begin
+                # unpack
+                corrected_idx_i = idx[i]
+                xi, particle_i, dx_i = @inbounds xi_vx[i][corrected_idx_i], particle[i], dxi[i]
 
-    return Vx_interp, Vy_interp, Vz_interp
+                # compute offsets and corrections
+                corrected_idx_i += vertex_offset(
+                    xi, particle_i, dx_i
+                )
+                cell_i = @inbounds xi
+            end
+
+            indices = Base.@ncall $N tuple corrected_idx
+            cells = Base.@ncall $N tuple cell
+
+            # F at the four centers
+            Fi = extract_field_corners(F, indices...)
+        end
+
+        return Fi, cells
+    end
+end
+
+@inline function vertex_offset(xi, pxi, di)
+    dist = normalised_distance(xi, pxi, di)
+    return (dist > 2) * 2 + (2 > dist > 1) * 1 + (-1 < dist < 0) * -1 + (dist < -1) * -2
 end


### PR DESCRIPTION
Drifting is not observed anymore in the examples in JustRelax.jl when using bilinear advection:

<img width="900" height="900" alt="174" src="https://github.com/user-attachments/assets/10c01162-9660-428f-aa62-f684eca489de" />
