### PR TITLE
Update jld2 checkpointing 

### DIFF
--- a/src/IO/JLD2.jl
+++ b/src/IO/JLD2.jl
@@ -14,6 +14,7 @@ function checkpointing_particles(
         t = nothing,
         dt = nothing,
         particle_args = nothing,
+        particle_args_reduced = nothing,
     )
     fname = checkpoint_name(dst)
     return checkpointing_particles(
@@ -26,6 +27,7 @@ function checkpointing_particles(
         t = t,
         dt = dt,
         particle_args = particle_args,
+        particle_args_reduced = particle_args_reduced,
     )
 end
 
@@ -39,6 +41,7 @@ function checkpointing_particles(
         t = nothing,
         dt = nothing,
         particle_args = nothing,
+        particle_args_reduced = nothing,
     )
     fname = checkpoint_name(dst, me)
     checkpointing_particles(
@@ -51,6 +54,7 @@ function checkpointing_particles(
         t = t,
         dt = dt,
         particle_args = particle_args,
+        particle_args_reduced = particle_args_reduced,
     )
     return nothing
 end
@@ -83,6 +87,7 @@ function checkpointing_particles(
         t = t,
         dt = dt,
         particle_args = particle_args,
+        particle_args_reduced = particle_args_reduced,
     )
     !isdir(dst) && mkpath(dst) # create folder in case it does not exist
 
@@ -99,6 +104,7 @@ function checkpointing_particles(
             :time => t,
             :timestep => dt,
             :particle_args => isnothing(particle_args) ? nothing : Array.(particle_args),
+            :particle_args_reduced => isnothing(particle_args_reduced) ? nothing : Array.(particle_args_reduced),
         )
         jldsave(tmpfname; args...)
 

--- a/test/test_save_load.jl
+++ b/test/test_save_load.jl
@@ -21,15 +21,16 @@ const backend = JustPIC.CPUBackend
     xvi = xv, yv = range(0, Lx, length = n), range(0, Ly, length = n)
 
     particles = JP2.init_particles(backend, nxcell, max_xcell, min_xcell, xvi...)
-    phases, = JP2.init_cell_arrays(particles, Val(1))
-    particle_args = (phases,)
+    phases, pT = JP2.init_cell_arrays(particles, Val(2))
+    particle_args = (phases,pT)
+    particle_args_reduced = (phases,)
     phase_ratios = JP2.PhaseRatios(backend, 2, ni)
     initial_elevation = Ly / 2
     chain = JP2.init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
     @views particles.index.data[:, 1:3, 1] .= 1.0
     @views particles.index.data[:, 4:6, 1] .= 0.0
 
-    JP2.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, chain = chain, particle_args = particle_args)
+    JP2.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, chain = chain, particle_args = particle_args, particle_args_reduced = particle_args_reduced)
 
     # test type conversion
     @test eltype(eltype(Array(phases))) === Float64
@@ -76,9 +77,11 @@ const backend = JustPIC.CPUBackend
     phase_ratios3 = data1["phase_ratios"]
     chain3 = data1["chain"]
     particle_args3 = data1["particle_args"]
+    particle_args_reduced3 = data1["particle_args_reduced"]
 
     @test chain3 isa JustPIC.MarkerChain{JustPIC.CPUBackend}
     @test particle_args3 isa Tuple
+    @test particle_args_reduced3 isa Tuple
     @test Array(particles).coords[1].data == particles3.coords[1].data
     @test Array(particles).coords[2].data == particles3.coords[2].data
     @test Array(particles).index.data == particles3.index.data
@@ -111,6 +114,7 @@ const backend = JustPIC.CPUBackend
         phases_gpu2 = T(phases3)
         chain_gpu = T(chain)
         particle_args_gpu2 = T.(particle_args)
+        particle_args_reduced_gpu2 = T.(particle_args_reduced)
 
         @test particles_gpu isa JustPIC.Particles{Backend}
         @test phase_ratios_gpu isa JustPIC.PhaseRatios{Backend}
@@ -126,6 +130,7 @@ const backend = JustPIC.CPUBackend
         @test phase_ratios_gpu2 isa JustPIC.PhaseRatios{Backend}
         @test chain_gpu isa JustPIC.MarkerChain{Backend}
         @test particle_args_gpu2 isa Tuple
+        @test particle_args_reduced_gpu2 isa Tuple
         @test last(typeof(phases_gpu2).parameters) <: T{Float64, 3}
         @test size(particles_gpu2.coords[1].data) == size(permutedims(particles.coords[1].data, (3, 2, 1)))
         @test size(particles_gpu2.coords[2].data) == size(permutedims(particles.coords[2].data, (3, 2, 1)))
@@ -163,16 +168,17 @@ end
     xvi = xv, yv, zv = range(0, Lx, length = n), range(0, Ly, length = n), range(0, Lz, length = n)
 
     particles = JP3.init_particles(backend, nxcell, max_xcell, min_xcell, xvi...)
-    phases, = JP3.init_cell_arrays(particles, Val(1))
+    phases, pT = JP3.init_cell_arrays(particles, Val(2))
     phase_ratios = JP3.PhaseRatios(backend, 2, ni)
-    particle_args = (phases,)
+    particle_args = (phases,pT)
+    particle_args_reduced = (phases,)
     initial_elevation = Ly / 2
     chain = JP2.init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
 
     @views particles.index.data[:, 1:3, 1] .= 1.0
     @views particles.index.data[:, 4:6, 1] .= 0.0
 
-    JP3.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios)
+    JP3.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, particle_args = particle_args, particle_args_reduced = particle_args_reduced)
 
     # test type conversion
     @test eltype(eltype(Array(phases))) === Float64
@@ -206,7 +212,11 @@ end
     phase_ratios3 = data1["phase_ratios"]
     chain3 = data1["chain"]
     particle_args3 = data1["particle_args"]
+    particle_args_reduced3 = data1["particle_args_reduced"]
 
+    @test chain3 isa Nothing
+    @test particle_args3 isa Tuple
+    @test particle_args_reduced3 isa Tuple
     @test Array(particles).coords[1].data == particles2.coords[1].data
     @test Array(particles).coords[2].data == particles2.coords[2].data
     @test Array(particles).index.data == particles2.index.data
@@ -251,6 +261,7 @@ end
         phase_ratios_gpu2 = T(phase_ratios3)
         phases_gpu2 = T(phases3)
         particle_args_gpu2 = T.(particle_args)
+        particle_args_reduced_gpu2 = T.(particle_args_reduced)
 
         @test particles_gpu isa JustPIC.Particles{Backend}
         @test phase_ratios_gpu isa JustPIC.PhaseRatios{Backend}
@@ -265,6 +276,7 @@ end
         @test particles_gpu2 isa JustPIC.Particles{Backend}
         @test phase_ratios_gpu2 isa JustPIC.PhaseRatios{Backend}
         @test particle_args_gpu2 isa Tuple
+        @test particle_args_reduced_gpu2 isa Tuple
         @test last(typeof(phases_gpu2).parameters) <: T{Float64, 3}
         @test size(particles_gpu2.coords[1].data) == size(permutedims(particles.coords[1].data, (3, 2, 1)))
         @test size(particles_gpu2.coords[2].data) == size(permutedims(particles.coords[2].data, (3, 2, 1)))

--- a/test/test_save_load.jl
+++ b/test/test_save_load.jl
@@ -24,13 +24,14 @@ const backend = JustPIC.CPUBackend
     phases, pT = JP2.init_cell_arrays(particles, Val(2))
     particle_args = (phases,pT)
     particle_args_reduced = (phases,)
+    particle_args_kwarg = (phases,)
     phase_ratios = JP2.PhaseRatios(backend, 2, ni)
     initial_elevation = Ly / 2
     chain = JP2.init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
     @views particles.index.data[:, 1:3, 1] .= 1.0
     @views particles.index.data[:, 4:6, 1] .= 0.0
 
-    JP2.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, chain = chain, particle_args = particle_args, particle_args_reduced = particle_args_reduced)
+    JP2.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, chain = chain, particle_args = particle_args, particle_args_reduced = particle_args_reduced, particle_args_kwarg = particle_args_kwarg)
 
     # test type conversion
     @test eltype(eltype(Array(phases))) === Float64
@@ -78,10 +79,12 @@ const backend = JustPIC.CPUBackend
     chain3 = data1["chain"]
     particle_args3 = data1["particle_args"]
     particle_args_reduced3 = data1["particle_args_reduced"]
+    particle_args_kwarg3 = data1["particle_args_kwarg"]
 
     @test chain3 isa JustPIC.MarkerChain{JustPIC.CPUBackend}
     @test particle_args3 isa Tuple
     @test particle_args_reduced3 isa Tuple
+    @test particle_args_kwarg3 isa Tuple
     @test Array(particles).coords[1].data == particles3.coords[1].data
     @test Array(particles).coords[2].data == particles3.coords[2].data
     @test Array(particles).index.data == particles3.index.data
@@ -115,6 +118,7 @@ const backend = JustPIC.CPUBackend
         chain_gpu = T(chain)
         particle_args_gpu2 = T.(particle_args)
         particle_args_reduced_gpu2 = T.(particle_args_reduced)
+        particle_args_kwarg_gpu2 = T.(particle_args_kwarg)
 
         @test particles_gpu isa JustPIC.Particles{Backend}
         @test phase_ratios_gpu isa JustPIC.PhaseRatios{Backend}
@@ -131,6 +135,7 @@ const backend = JustPIC.CPUBackend
         @test chain_gpu isa JustPIC.MarkerChain{Backend}
         @test particle_args_gpu2 isa Tuple
         @test particle_args_reduced_gpu2 isa Tuple
+        @test particle_args_kwarg_gpu2 isa Tuple
         @test last(typeof(phases_gpu2).parameters) <: T{Float64, 3}
         @test size(particles_gpu2.coords[1].data) == size(permutedims(particles.coords[1].data, (3, 2, 1)))
         @test size(particles_gpu2.coords[2].data) == size(permutedims(particles.coords[2].data, (3, 2, 1)))
@@ -172,13 +177,14 @@ end
     phase_ratios = JP3.PhaseRatios(backend, 2, ni)
     particle_args = (phases,pT)
     particle_args_reduced = (phases,)
+    particle_args_kwarg = (phases,)
     initial_elevation = Ly / 2
     chain = JP2.init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
 
     @views particles.index.data[:, 1:3, 1] .= 1.0
     @views particles.index.data[:, 4:6, 1] .= 0.0
 
-    JP3.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, particle_args = particle_args, particle_args_reduced = particle_args_reduced)
+    JP3.checkpointing_particles(pwd(), particles; phases = phases, phase_ratios = phase_ratios, particle_args = particle_args, particle_args_reduced = particle_args_reduced, particle_args_kwarg = particle_args_kwarg)
 
     # test type conversion
     @test eltype(eltype(Array(phases))) === Float64
@@ -213,10 +219,12 @@ end
     chain3 = data1["chain"]
     particle_args3 = data1["particle_args"]
     particle_args_reduced3 = data1["particle_args_reduced"]
+    particle_args_kwarg3 = data1["particle_args_kwarg"]
 
     @test chain3 isa Nothing
     @test particle_args3 isa Tuple
     @test particle_args_reduced3 isa Tuple
+    @test particle_args_kwarg3 isa Tuple
     @test Array(particles).coords[1].data == particles2.coords[1].data
     @test Array(particles).coords[2].data == particles2.coords[2].data
     @test Array(particles).index.data == particles2.index.data


### PR DESCRIPTION
This updates the function to feature an option to save whatever additional argument one would like to have. For example, in recent JustRelax examples we have used `particle_args_reduced` which are not saved by default. This way the user is more flexible. Especially when writing a restart script. 