### PR TITLE
Semi-Lagrangian MC angle smoothing

### DIFF
--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -427,6 +427,11 @@ module _2D
         return nothing
     end
 
+    function JustPIC._2D.smooth_slopes!(chain::MarkerChain{AMDGPUBackend}, max_angle)
+        smooth_slopes!(chain, max_angle)
+        return nothing
+    end
+
     function JustPIC._2D.fill_chain_from_vertices!(
             chain::MarkerChain{AMDGPUBackend}, topo_y
         )

--- a/ext/JustPICAMDGPUExt.jl
+++ b/ext/JustPICAMDGPUExt.jl
@@ -455,9 +455,10 @@ module _2D
             V,
             grid_vxi,
             xvi,
-            dt,
+            dt;
+            max_slope_angle = 45.0,
         )
-        return semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt)
+        return semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt; max_slope_angle = max_slope_angle)
     end
 
     function JustPIC._2D.compute_rock_fraction!(

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -424,6 +424,11 @@ module _2D
         return semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt)
     end
 
+    function JustPIC._2D.smooth_slopes!(chain::MarkerChain{CUDABackend}, max_angle)
+        smooth_slopes!(chain, max_angle)
+        return nothing
+    end
+
     function JustPIC._2D.compute_rock_fraction!(
             ratios, chain::MarkerChain{CUDABackend}, xvi, dxi
         )

--- a/ext/JustPICCUDAExt.jl
+++ b/ext/JustPICCUDAExt.jl
@@ -419,9 +419,10 @@ module _2D
             V,
             grid_vxi,
             xvi,
-            dt,
+            dt;
+            max_slope_angle = 45.0,
         )
-        return semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt)
+        return semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt; max_slope_angle = max_slope_angle)
     end
 
     function JustPIC._2D.smooth_slopes!(chain::MarkerChain{CUDABackend}, max_angle)

--- a/scripts/rotating_marker_chain_SML_topography.jl
+++ b/scripts/rotating_marker_chain_SML_topography.jl
@@ -53,7 +53,7 @@ function main()
     volcano_center = 0.5
     volcano_height = 0.5
     volcano_width = 0.1
-    gaussian_elevation = volcano_height .* exp.(-((xv .- volcano_center).^2) ./ (2 * volcano_width^2))
+    gaussian_elevation = volcano_height .* exp.(-((xv .- volcano_center) .^ 2) ./ (2 * volcano_width^2))
     initial_elevation = Ly / 2
     chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
     steep_topography = Ly / 2 .+ gaussian_elevation

--- a/scripts/rotating_marker_chain_SML_topography.jl
+++ b/scripts/rotating_marker_chain_SML_topography.jl
@@ -1,0 +1,80 @@
+using JustPIC
+using JustPIC._2D
+using ParallelStencil
+@init_parallel_stencil(Threads, Float64, 2)
+using GLMakie
+
+const backend = JustPIC.CPUBackend
+
+function expand_range(x::AbstractRange)
+    dx = x[2] - x[1]
+    n = length(x)
+    x1, x2 = extrema(x)
+    xI = x1 - dx
+    xF = x2 + dx
+    return LinRange(xI, xF, n + 2)
+end
+
+# Analytical flow solution
+vi_stream(x) = π * 1.0e-5 * (x - 0.5)
+
+function main()
+
+    # Initialize particles -------------------------------
+    n = 51
+    # nx = n - 1  # Removed unused variable
+    Lx = Ly = 1.0
+    # nodal vertices
+    xvi = xv, yv = LinRange(0, Lx, n), LinRange(0, Ly, n)
+    dx, dy = xv[2] - xv[1], yv[2] - yv[1]  # Removed unused variable dxi
+    # nodal centers
+    xc, yc = LinRange(0 + dx / 2, Lx - dx / 2, n - 1), LinRange(0 + dy / 2, Ly - dy / 2, n - 1)
+    # staggered grid velocity nodal locations
+    grid_vx = xv, expand_range(yc)
+    grid_vy = expand_range(xc), yv
+    grid_vxi = grid_vx, grid_vy
+
+    # Cell fields -------------------------------
+    Vx = TA(backend)([-vi_stream(y) for x in grid_vx[1], y in grid_vx[2]])
+    Vy = TA(backend)([ vi_stream(x) for x in grid_vy[1], y in grid_vy[2]])
+
+    xc0 = yc0 = 0.25
+    R = 24 * dx
+    V = Vx, Vy
+
+    w = π * 1.0e-5  # angular velocity
+    period = 1  # revolution number
+    tmax = period / (w / (2 * π))
+    dt = 200.0
+
+    nxcell, min_xcell, max_xcell = 12, 6, 24
+    initial_elevation = fill(Ly / 2, length(xv))
+    # Add Gaussian elevation to mimic a volcano
+    volcano_center = 0.5
+    volcano_height = 0.5
+    volcano_width = 0.1
+    gaussian_elevation = volcano_height .* exp.(-((xv .- volcano_center).^2) ./ (2 * volcano_width^2))
+    initial_elevation = Ly / 2
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, initial_elevation)
+    steep_topography = Ly / 2 .+ gaussian_elevation
+    fill_chain_from_vertices!(chain, steep_topography)
+    method = RungeKutta4()
+
+    for _ in 1:125
+        semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt; max_slope_angle = 45.0)
+    end
+
+    f = Figure(size = (1200, 1200))
+    ax = Axis(f[1, 1])
+    # vector of shapes
+    poly!(
+        ax,
+        Rect(0, 0, 1, 1),
+        color = :lightgray,
+    )
+    lines!(ax, xvi[1], chain.h_vertices, color = :blue, linewidth = 4)
+    display(f)
+    return nothing
+end
+
+main()

--- a/src/MarkerChain/Advection/backtrack.jl
+++ b/src/MarkerChain/Advection/backtrack.jl
@@ -2,13 +2,13 @@ using Statistics
 
 function semilagrangian_advection_markerchain!(
         chain::MarkerChain, method::AbstractAdvectionIntegrator, V, grid_vxi, grid, dt;
-        max_slope_angle_deg = 45.0
+        max_slope_angle = 45.0
     )
 
     semilagrangian_advection!(chain, method, V, grid_vxi, grid, dt)
 
     # Apply LaMEM-style slope limiting
-    smooth_slopes!(chain, deg2rad(max_slope_angle_deg))
+    smooth_slopes!(chain, deg2rad(max_slope_angle))
 
     # Mass conservation
     chain.h_vertices .+= mean(chain.h_vertices) - mean(chain.h_vertices0)
@@ -66,3 +66,37 @@ end
 
     return nothing
 end
+
+# function compute_topography_vertex_with_neighbors!(chain::MarkerChain)
+#     (; coords, index, cell_vertices, h_vertices) = chain
+
+#     @parallel (1:length(cell_vertices)) _compute_h_vertex_with_neighbors!(
+#         h_vertices, coords, index, cell_vertices
+#     )
+
+#     return nothing
+# end
+
+# @parallel_indices (ivertex) function _compute_h_vertex_with_neighbors!(
+#         h_vertices, coords, index, cell_vertices
+#     )
+#     xcorner = cell_vertices[ivertex]
+
+#     # Find which cell this vertex belongs to
+#     I = max(1, min(length(index), ivertex))
+
+#     # Check if we're at the boundaries and handle accordingly
+#     if I == 1 || I == length(index)
+#         # For boundary vertices, use simpler interpolation
+#         x_cell = @cell coords[1][I]
+#         y_cell = @cell coords[2][I]
+#         h_vertices[ivertex] = interp1D_extremas(xcorner, x_cell, y_cell)
+#     else
+#         # For interior vertices, use the neighbor-aware interpolation
+#         x_cell = @cell coords[1][I]
+#         y_cell = @cell coords[2][I]
+#         h_vertices[ivertex] = interp1D_inner(xcorner, x_cell, y_cell, coords, I)
+#     end
+
+#     return nothing
+# end

--- a/src/MarkerChain/Advection/backtrack.jl
+++ b/src/MarkerChain/Advection/backtrack.jl
@@ -1,13 +1,19 @@
 using Statistics
 
 function semilagrangian_advection_markerchain!(
-        chain::MarkerChain, method::AbstractAdvectionIntegrator, V, grid_vxi, grid, dt
+        chain::MarkerChain, method::AbstractAdvectionIntegrator, V, grid_vxi, grid, dt;
+        max_slope_angle_deg = 45.0
     )
 
     semilagrangian_advection!(chain, method, V, grid_vxi, grid, dt)
-    # correct topo to conserve mass
+
+    # Apply LaMEM-style slope limiting
+    smooth_slopes!(chain, deg2rad(max_slope_angle_deg))
+
+    # Mass conservation
     chain.h_vertices .+= mean(chain.h_vertices) - mean(chain.h_vertices0)
-    # reconstruct chain from vertices
+
+    # Reconstruct particles from the updated vertices
     reconstruct_chain_from_vertices!(chain)
     # update old nodal topography
     copyto!(chain.h_vertices0, chain.h_vertices)

--- a/src/MarkerChain/Advection/backtrack.jl
+++ b/src/MarkerChain/Advection/backtrack.jl
@@ -66,37 +66,3 @@ end
 
     return nothing
 end
-
-# function compute_topography_vertex_with_neighbors!(chain::MarkerChain)
-#     (; coords, index, cell_vertices, h_vertices) = chain
-
-#     @parallel (1:length(cell_vertices)) _compute_h_vertex_with_neighbors!(
-#         h_vertices, coords, index, cell_vertices
-#     )
-
-#     return nothing
-# end
-
-# @parallel_indices (ivertex) function _compute_h_vertex_with_neighbors!(
-#         h_vertices, coords, index, cell_vertices
-#     )
-#     xcorner = cell_vertices[ivertex]
-
-#     # Find which cell this vertex belongs to
-#     I = max(1, min(length(index), ivertex))
-
-#     # Check if we're at the boundaries and handle accordingly
-#     if I == 1 || I == length(index)
-#         # For boundary vertices, use simpler interpolation
-#         x_cell = @cell coords[1][I]
-#         y_cell = @cell coords[2][I]
-#         h_vertices[ivertex] = interp1D_extremas(xcorner, x_cell, y_cell)
-#     else
-#         # For interior vertices, use the neighbor-aware interpolation
-#         x_cell = @cell coords[1][I]
-#         y_cell = @cell coords[2][I]
-#         h_vertices[ivertex] = interp1D_inner(xcorner, x_cell, y_cell, coords, I)
-#     end
-
-#     return nothing
-# end

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -111,7 +111,7 @@ function smooth_slopes!(chain::MarkerChain, max_angle::Real)
     (; h_vertices, cell_vertices) = chain
     n = length(h_vertices)
 
-n < 3 && return nothing  # Need at least 3 vertices for smoothing
+    n < 3 && return nothing  # Need at least 3 vertices for smoothing
 
     tan_max_angle = tan(max_angle)
 

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -105,3 +105,52 @@ function _reconstruct_h_from_vertex_kernel!(
 
     return nothing
 end
+
+# LaMEM-style slope limiting for numerical stability
+function smooth_slopes!(chain::MarkerChain, max_angle::Real)
+    (; h_vertices, cell_vertices) = chain
+    n = length(h_vertices)
+
+    if n < 3
+        return  # Need at least 3 vertices for smoothing
+    end
+
+    tan_max_angle = tan(max_angle)
+
+    # Create temporary array for smoothed values (avoid allocation inside kernel)
+    h_smoothed = similar(h_vertices)
+    copyto!(h_smoothed, h_vertices)  # Initialize with original values
+
+    # GPU-parallel smoothing kernel
+    @parallel (2:(n-1)) smooth_slopes_kernel!(
+        h_smoothed, h_vertices, cell_vertices, tan_max_angle
+    )
+
+    # Copy results back
+    copyto!(h_vertices, h_smoothed)
+    return nothing
+end
+
+@parallel_indices (i) function smooth_slopes_kernel!(
+        h_smoothed, h_vertices, cell_vertices, tan_max_angle
+    )
+    # Each thread handles one vertex independently
+    dx_left = cell_vertices[i] - cell_vertices[i-1]
+    dx_right = cell_vertices[i+1] - cell_vertices[i]
+    dh_left = h_vertices[i] - h_vertices[i-1]
+    dh_right = h_vertices[i+1] - h_vertices[i]
+
+    slope_left = abs(dh_left / dx_left)
+    slope_right = abs(dh_right / dx_right)
+
+    # If either adjacent slope is too steep, apply smoothing
+    if slope_left > tan_max_angle || slope_right > tan_max_angle
+        # Simple 3-point averaging
+        h_smoothed[i] = 0.25 * (h_vertices[i-1] + 2*h_vertices[i] + h_vertices[i+1])
+    else
+        # Keep original value
+        h_smoothed[i] = h_vertices[i]
+    end
+
+    return nothing
+end

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -117,12 +117,10 @@ function smooth_slopes!(chain::MarkerChain, max_angle::Real)
 
     tan_max_angle = tan(max_angle)
 
-    # Create temporary array for smoothed values (avoid allocation inside kernel)
     h_smoothed = similar(h_vertices)
     copyto!(h_smoothed, h_vertices)  # Initialize with original values
 
-    # GPU-parallel smoothing kernel
-    @parallel (2:(n-1)) smooth_slopes_kernel!(
+    @parallel (2:(n - 1)) smooth_slopes_kernel!(
         h_smoothed, h_vertices, cell_vertices, tan_max_angle
     )
 
@@ -135,10 +133,10 @@ end
         h_smoothed, h_vertices, cell_vertices, tan_max_angle
     )
     # Each thread handles one vertex independently
-    dx_left = cell_vertices[i] - cell_vertices[i-1]
-    dx_right = cell_vertices[i+1] - cell_vertices[i]
-    dh_left = h_vertices[i] - h_vertices[i-1]
-    dh_right = h_vertices[i+1] - h_vertices[i]
+    dx_left = cell_vertices[i] - cell_vertices[i - 1]
+    dx_right = cell_vertices[i + 1] - cell_vertices[i]
+    dh_left = h_vertices[i] - h_vertices[i - 1]
+    dh_right = h_vertices[i + 1] - h_vertices[i]
 
     slope_left = abs(dh_left / dx_left)
     slope_right = abs(dh_right / dx_right)
@@ -146,7 +144,7 @@ end
     # If either adjacent slope is too steep, apply smoothing
     if slope_left > tan_max_angle || slope_right > tan_max_angle
         # Simple 3-point averaging
-        h_smoothed[i] = 0.25 * (h_vertices[i-1] + 2*h_vertices[i] + h_vertices[i+1])
+        h_smoothed[i] = 0.25 * (h_vertices[i - 1] + 2 * h_vertices[i] + h_vertices[i + 1])
     else
         # Keep original value
         h_smoothed[i] = h_vertices[i]

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -111,9 +111,7 @@ function smooth_slopes!(chain::MarkerChain, max_angle::Real)
     (; h_vertices, cell_vertices) = chain
     n = length(h_vertices)
 
-    if n < 3
-        return  # Need at least 3 vertices for smoothing
-    end
+n < 3 && return nothing  # Need at least 3 vertices for smoothing
 
     tan_max_angle = tan(max_angle)
 


### PR DESCRIPTION
This PR attempts to limit the noise in the marker chain when using the SLS advection by introducing a LaMEM style angle smoothing step. 

### General remarks:
- `advect_markerchain!()` seems to smooth topography too much due to a constant resampling and reconstruction
- new SLS routine produces NaNs randomly in the rotation script (see [here](https://github.com/JuliaGeodynamics/JustPIC.jl/blob/pa-SLS_MC/scripts/rotating_marker_chain_SML_topography.jl))
- current hack with ` h_vertices[i] -= (hᵢ_new - h_vertices[I])` is ok but I guess is not fully consistent with a pure SLS. The hack results in small noise being amplified as it becomes ` 2*h_vertices[i] - hᵢ_new`

Either we leave it as is for now or think of a way to fix this which would require a bit more coding and additional routines (from what I currently understand).  


Figures resulting from the rotation script:
<img width="312" height="340" alt="Screenshot 2025-08-27 at 12 18 01" src="https://github.com/user-attachments/assets/93d1b383-b51a-4b51-a2a5-82a90003b2cd" /> <img width="312" height="340" alt="Screenshot 2025-08-27 at 12 18 16" src="https://github.com/user-attachments/assets/3a458b0b-eace-4527-bede-a5d5c8444c18" />
