### PR TITLE
[CI] Include Julia v1.12 in run_tests.yml

### DIFF
--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -3,8 +3,8 @@ steps:
     matrix:
       setup:
         version:
-          - "1.10"
           - "1.11"
+          - "1.12"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -32,6 +32,7 @@ steps:
       setup:
         version:
           - "1.11"
+          - "1.12"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"


### PR DESCRIPTION
Added Julia version 1.12 to the test matrix.

### Whats the purpose of this PR?
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Other, please explain

**Describe it in more detail below:**

Drop GPU CI on v1.10 and add v1.12

**Checklist**
- [ ] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
- [ ] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [ ] The new code follows the [contributor guidelines](https://github.com/JuliaGeodynamics/JustPIC.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)
