### PR TITLE
Bump AMDGPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ JustPICAMDGPUExt = "AMDGPU"
 JustPICCUDAExt = "CUDA"
 
 [compat]
-AMDGPU = "0.8, 0.9, 1"
+AMDGPU = "0.8, 0.9, 1, 2"
 Atomix = "1"
 CUDA = "5"
 CellArrays = "0.3"

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ JustPICAMDGPUExt = "AMDGPU"
 JustPICCUDAExt = "CUDA"
 
 [compat]
-AMDGPU = "0.8, 0.9, 1, 2"
+AMDGPU = "1, 2"
 Atomix = "1"
 CUDA = "5"
 CellArrays = "0.3"


### PR DESCRIPTION
Without it currently prevent JustRelax to use latest version of AMDGPU.jl

Upon merging we should tag a patch release.