### PR TITLE
Fix marker-chain mean conservation and cell movement

### DIFF
--- a/docs/src/marker_chain.md
+++ b/docs/src/marker_chain.md
@@ -28,6 +28,10 @@ vertices (`h_vertices`). The most useful fields are:
 Marker precision follows the grid/elevation element type, so a `Float32` grid produces a
 `Float32` chain — this is required on Metal, which has no `Float64`.
 
+`cell_vertices` must be finite, strictly increasing, and uniformly spaced. Marker lookup,
+resampling, and movement use one constant cell width; construction throws an
+`ArgumentError` when this grid contract is violated.
+
 ## Creating a chain
 
 Instantiate a chain with a constant elevation `h`:

--- a/src/MarkerChain/Advection/advection.jl
+++ b/src/MarkerChain/Advection/advection.jl
@@ -1,5 +1,3 @@
-using Statistics
-
 """
     advect_markerchain!(chain, method, V, grid_vxi, dt)
 
@@ -21,12 +19,12 @@ function advect_markerchain!(
 
     # interpolate from markers to grid
     compute_topography_vertex!(chain)
-    # average h_vertices0 and h_vertices and store in h_vertices
-    # @. chain.h_vertices = (chain.h_vertices0 + chain.h_vertices) / 2
     # correct topo to conserve mass
-    chain.h_vertices .-= mean(chain.h_vertices) - mean(chain.h_vertices0)
+    chain.h_vertices .-= mean_height(chain.h_vertices) - mean_height(chain.h_vertices0)
     # reconstruct chain from vertices
     reconstruct_chain_from_vertices!(chain)
+    copyto!(chain.coords0[1].data, chain.coords[1].data)
+    copyto!(chain.coords0[2].data, chain.coords[2].data)
     # update old nodal topography
     copyto!(chain.h_vertices0, chain.h_vertices)
 

--- a/src/MarkerChain/Advection/backtrack.jl
+++ b/src/MarkerChain/Advection/backtrack.jl
@@ -1,5 +1,3 @@
-using Statistics
-
 """
     semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, grid, dt; max_slope_angle = 45.0)
 
@@ -28,10 +26,12 @@ function semilagrangian_advection_markerchain!(
     smooth_slopes!(chain, deg2rad(max_slope_angle))
 
     # Mass conservation
-    chain.h_vertices .-= mean(chain.h_vertices) - mean(chain.h_vertices0)
+    chain.h_vertices .-= mean_height(chain.h_vertices) - mean_height(chain.h_vertices0)
 
     # Reconstruct particles from the updated vertices
     reconstruct_chain_from_vertices!(chain)
+    copyto!(chain.coords0[1].data, chain.coords[1].data)
+    copyto!(chain.coords0[2].data, chain.coords[2].data)
     # update old nodal topography
     copyto!(chain.h_vertices0, chain.h_vertices)
 
@@ -58,6 +58,7 @@ function semilagrangian_advection!(
         dt,
     ) where {N, T}
     (; h_vertices) = chain
+    h_old = copy(h_vertices)
 
     # recast integrator/timestep/grids to the topography precision so Float32 backends
     # (e.g. Metal) are not silently promoted; `recast_grid` also rebuilds the grid ranges
@@ -67,6 +68,7 @@ function semilagrangian_advection!(
     dt = convert(Tc, dt)
     grid_vxi = recast_grid(grid_vxi, Tc)
     grid = recast_grid(grid, Tc)
+    dx_chain = cell_length(chain)
 
     # compute some basic stuff
     ni = length(h_vertices)
@@ -76,7 +78,7 @@ function semilagrangian_advection!(
     # launch parallel advection kernel
     launch!(
         ka_backend(h_vertices), semilagrangian_advection_markerchain_kernel!, ni,
-        h_vertices, method, V, grid_vxi, grid, local_limits, dxi, dt
+        h_vertices, h_old, method, V, grid_vxi, grid, local_limits, dxi, dx_chain, dt
     )
     return nothing
 end
@@ -86,19 +88,30 @@ end
 # Semilagrangian backtracking kernel for staggered grids.
 @kernel function semilagrangian_advection_markerchain_kernel!(
         h_vertices,
+        h_old,
         method::AbstractAdvectionIntegrator,
         V::NTuple{N, T},
         grid_vxi,
         grid,
         local_limits,
         dxi,
+        dx_chain,
         dt,
     ) where {N, T}
     i = @index(Global)
 
-    hᵢ = h_vertices[i]
+    hᵢ = h_old[i]
     pᵢ = grid[1][i], hᵢ
     # backtrack particle position
-    _, hᵢ_new = advect_particle_markerchain(method, pᵢ, V, grid_vxi, local_limits, dxi, dt; backtracking = true)
-    h_vertices[i] -= (hᵢ_new - h_vertices[i])
+    x_departure, y_departure = advect_particle_markerchain(
+        method, pᵢ, V, grid_vxi, local_limits, dxi, dt; backtracking = true
+    )
+    h_departure = _interpolate_topography(x_departure, grid[1], h_old, dx_chain)
+    h_vertices[i] = h_departure + hᵢ - y_departure
+end
+
+@inline function _interpolate_topography(xq, xv, h, dx)
+    x = clamp(xq, xv[1], xv[end])
+    i = clamp(cell_index(x, xv, dx), 1, length(h) - 1)
+    return _interp1D(x, xv[i], xv[i + 1], h[i], h[i + 1])
 end

--- a/src/MarkerChain/areas.jl
+++ b/src/MarkerChain/areas.jl
@@ -216,8 +216,8 @@ end
             origin = (ox, oy) .+ (masks_x[c], masks_y[c])
             ## now we need to interpolate the segment of the chain to the boundaries of the new cell
             # segment of the chain
-            p1 = GridGeometryUtils.Point(x[l], y[k])
-            p2 = GridGeometryUtils.Point(x[l + 1], y[k + 1])
+            p1 = GridGeometryUtils.Point(x[l], y[l])
+            p2 = GridGeometryUtils.Point(x[l + 1], y[l + 1])
             # create a line from the two points
             l = Line(p1, p2)
             # evaluate the line at the origin and origin + dx / 2

--- a/src/MarkerChain/bilinear_MC.jl
+++ b/src/MarkerChain/bilinear_MC.jl
@@ -1,3 +1,5 @@
+using Statistics
+
 """
     compute_topography_vertex!(chain::MarkerChain)
 
@@ -10,53 +12,80 @@ function compute_topography_vertex!(chain::MarkerChain)
     (; coords, index, cell_vertices, h_vertices) = chain
     chain_x, chain_y = coords
 
-    _dx = inv(cell_vertices[2] - cell_vertices[1])
-
     launch!(
         ka_backend(h_vertices), _compute_h_vertex!, length(cell_vertices),
-        h_vertices, chain_x, chain_y, cell_vertices, index, _dx
+        h_vertices, chain_x, chain_y, cell_vertices, index
     )
 
     return nothing
 end
 
 @kernel function _compute_h_vertex!(
-        h_vertices, chain_x, chain_y, cell_vertices, index, _dx
+        h_vertices, chain_x, chain_y, cell_vertices, index
     )
     ivertex = @index(Global)
     _compute_h_vertex_kernel!(
-        h_vertices, chain_x, chain_y, cell_vertices, index, _dx, ivertex
+        h_vertices, chain_x, chain_y, cell_vertices, index, ivertex
     )
 end
 
 function _compute_h_vertex_kernel!(
-        h_vertices, chain_x, chain_y, cell_vertices, index, _dx::T, ivertex
-    ) where {T}
-    h = zero(T)
-    ω = zero(T)
+        h_vertices, chain_x, chain_y, cell_vertices, index, ivertex
+    )
     xcorner = cell_vertices[ivertex]
+    h = zero(xcorner)
+    n = 0
 
-    # iterate over cells on the left and right hand sides of the vertex
-    multiplier = -one(T)
     for j in (ivertex - 1):ivertex
         if 0 < j < length(cell_vertices)
-            for ip in cellaxes(index)
-                CAI.@index(index[ip, j]) || continue
-
-                x_m = CAI.@index chain_x[ip, j]
-                y_m = CAI.@index chain_y[ip, j]
-                dx_m = multiplier * (x_m - xcorner)
-                ωᵢ = @muladd one(T) - dx_m * _dx
-                h += y_m * ωᵢ
-                ω += ωᵢ
-            end
+            h_cell, isvalid = _fit_cell_height(chain_x, chain_y, index, j, xcorner)
+            h += ifelse(isvalid, h_cell, zero(h_cell))
+            n += isvalid
         end
-        multiplier = one(T)
     end
-    h_vertices[ivertex] = h / ω
+    iszero(n) || (h_vertices[ivertex] = h / n)
 
     return nothing
 end
+
+@inline function _fit_cell_height(chain_x, chain_y, index, icell, xq)
+    n = 0
+    sd = zero(xq)
+    sy = zero(xq)
+    sdd = zero(xq)
+    sdy = zero(xq)
+    for ip in cellaxes(index)
+        CAI.@index(index[ip, icell]) || continue
+        x = CAI.@index chain_x[ip, icell]
+        y = CAI.@index chain_y[ip, icell]
+        d = x - xq
+        n += 1
+        sd += d
+        sy += y
+        sdd += d * d
+        sdy += d * y
+    end
+
+    iszero(n) && return zero(xq), false
+    dmean = sd / n
+    ymean = sy / n
+    denominator = sdd - sd * dmean
+    slope = ifelse(iszero(denominator), zero(xq), (sdy - sd * ymean) / denominator)
+    return muladd(-slope, dmean, ymean), true
+end
+
+"""
+    mean_height(chain::MarkerChain)
+
+Return the domain mean of the piecewise-linear vertex topography.
+"""
+function mean_height(h::AbstractVector)
+    n = length(h)
+    endpoints = sum(@view h[1:1]) + sum(@view h[n:n])
+    return (n * mean(h) - endpoints / 2) / (n - 1)
+end
+
+mean_height(chain::MarkerChain) = mean_height(chain.h_vertices)
 
 ######################################
 

--- a/src/MarkerChain/init.jl
+++ b/src/MarkerChain/init.jl
@@ -3,6 +3,8 @@
 
 Create a 2D `MarkerChain` sampled along the horizontal grid `xv`.
 
+The vertices in `xv` must be finite, strictly increasing, and uniformly spaced.
+
 `nxcell` controls the initial number of markers per cell, while
 `initial_elevation` can be either a scalar or a vector specifying the initial
 surface height.
@@ -17,7 +19,11 @@ function init_markerchain(
     T = initial_elevation isa AbstractArray ? promote_type(eltype(xv), eltype(initial_elevation)) : promote_type(eltype(xv), typeof(initial_elevation))
     xv = recast_grid(xv, T)
     nx = length(xv) - 1
-    dx = xv[2] - xv[1]
+    0 < nxcell ≤ max_xcell || throw(ArgumentError("nxcell must satisfy 0 < nxcell ≤ max_xcell"))
+    0 < min_xcell ≤ max_xcell || throw(ArgumentError("min_xcell must satisfy 0 < min_xcell ≤ max_xcell"))
+    initial_elevation isa AbstractArray && length(initial_elevation) != nx + 1 &&
+        throw(DimensionMismatch("initial_elevation must have one value per grid vertex"))
+    dx = _uniform_grid_spacing(xv)
     dx_chain = dx / (nxcell + 1)
     initial_elevation = initial_elevation isa AbstractArray ? convert.(T, initial_elevation) : convert(T, initial_elevation)
     px, py = ntuple(_ -> cell_array(backend, convert(T, NaN), (max_xcell,), (nx,)), Val(2))
@@ -28,7 +34,10 @@ function init_markerchain(
         px, py, index, xv, initial_elevation, dx_chain, nxcell, max_xcell
     )
     coords = px, py
-    coords0 = px, py
+    px0, py0 = ntuple(_ -> cell_array(backend, convert(T, NaN), (max_xcell,), (nx,)), Val(2))
+    copyto!(px0.data, px.data)
+    copyto!(py0.data, py.data)
+    coords0 = px0, py0
     h_vertices = TA(backend)(initial_elevation isa AbstractArray ? initial_elevation : fill(initial_elevation, nx + 1))
     h_vertices0 = copy(h_vertices)
 
@@ -59,11 +68,13 @@ end
 
     # lower-left corner of the cell
     x0 = x[i]
-    initial_elevation0 = initial_elevation[i]
+    elevation_left = initial_elevation[i]
+    elevation_right = initial_elevation[i + 1]
     # fill index array
     for ip in 1:nxcell
+        fraction = convert(T, ip) / convert(T, nxcell + 1)
         CAI.@index px[ip, i] = x0 + dx_chain * ip
-        CAI.@index py[ip, i] = initial_elevation0
+        CAI.@index py[ip, i] = elevation_left + (elevation_right - elevation_left) * fraction
         CAI.@index index[ip, i] = true
     end
 end
@@ -125,32 +136,14 @@ function first_last_particle_incell(topo_x, cell_vertices, icell)
     xlims = cell_vertices[icell], cell_vertices[icell + 1]
 
     ifirst = 1
-    ilast = length(topo_x)
-    x1 = topo_x[1]
-    previous_incell = xlims[1] < x1 < xlims[2]
-
-    first_found = false
-    last_found = false
-
-    x = topo_x[2]
-    for i in 2:(ilast - 1)
-        incell = xlims[1] < x < xlims[2]
-
-        if !previous_incell && incell
-            ifirst = i
-            first_found = true
-        end
-
-        xnext = topo_x[i + 1]
-        next_incell = xlims[1] < xnext < xlims[2]
-        if incell && !next_incell
+    ilast = 0
+    for i in eachindex(topo_x)
+        if xlims[1] < topo_x[i] < xlims[2]
+            iszero(ilast) && (ifirst = i)
             ilast = i
-            last_found = true
+        elseif !iszero(ilast)
+            break
         end
-
-        first_found * last_found && break
-
-        x, previous_incell = xnext, incell
     end
 
     return ifirst, ilast

--- a/src/MarkerChain/move.jl
+++ b/src/MarkerChain/move.jl
@@ -4,28 +4,64 @@
 Reassign markers to the correct columns of `chain` after their coordinates have
 been updated.
 
-Markers that crossed a column boundary are moved into the neighbouring column's
+Markers that crossed column boundaries are moved into their destination column's
 slots, keeping the coordinate arrays consistent with the per-column occupancy
-mask. The horizontal grid and spacing are taken from `chain.cell_vertices`.
+mask. A marker may cross any number of columns in one call. The horizontal grid
+and spacing are taken from `chain.cell_vertices`.
 """
 function move_particles!(chain::MarkerChain)
     (; coords, index, cell_vertices) = chain
-    dxi = compute_dx(cell_vertices)
+    dxi = cell_length(chain)
     nxi = size(index, 1)
     grid = cell_vertices
 
-    launch!(ka_backend(index), move_particles_launcher!, nxi, coords, grid, dxi, index)
+    cell_jumps = similar(chain.h_vertices, Int, nxi)
+    launch!(
+        ka_backend(index), maximum_cell_jump!, nxi,
+        cell_jumps, coords, grid, dxi, index, nxi
+    )
+    max_jump = maximum(cell_jumps)
+
+    # Sources of the same color are farther apart than the diameter of their
+    # possible destination intervals. They therefore cannot write to the same
+    # cell, even when markers cross multiple columns in one timestep.
+    ncolors = 2 * max_jump + 1
+    n_color_cells = cld(nxi, ncolors)
+    for offset in 1:min(ncolors, nxi)
+        launch!(
+            ka_backend(index), move_particles_launcher!, n_color_cells,
+            coords, grid, dxi, index, offset, nxi, ncolors
+        )
+    end
 
     return nothing
 end
 
-@kernel function move_particles_launcher!(coords, grid, dxi, index)
+@kernel function maximum_cell_jump!(cell_jumps, coords, grid, dxi, index, nxi)
     i = @index(Global)
-    _move_particles!(coords, grid, dxi, index, i)
+    corner_xi = corner_coordinate(grid, i)
+    max_jump = 0
+
+    for ip in cellaxes(index)
+        doskip(index, ip, i) && continue
+        pᵢ = cache_particle(coords, ip, i)
+        (!isfinite(pᵢ[1]) || !isfinite(pᵢ[2])) && continue
+        isincell(pᵢ[1], corner_xi, dxi) && continue
+
+        new_cell = cell_index(pᵢ[1], grid, dxi)
+        if 1 ≤ new_cell ≤ nxi
+            max_jump = max(max_jump, abs(new_cell - i))
+        end
+    end
+
+    cell_jumps[i] = max_jump
 end
 
-chop(I::NTuple{2, T}) where {T} = I[1]
-chop(I::NTuple{3, T}) where {T} = I[1], I[2]
+@kernel function move_particles_launcher!(coords, grid, dxi, index, offset, nxi, ncolors)
+    i0 = @index(Global)
+    i = ncolors * (i0 - 1) + offset
+    i ≤ nxi && _move_particles!(coords, grid, dxi, index, i)
+end
 
 function _move_particles!(coords, grid, dxi, index, idx)
     # coordinate of the lower-most-left coordinate of the parent cell
@@ -36,7 +72,7 @@ function _move_particles!(coords, grid, dxi, index, idx)
         doskip(index, ip, idx) && continue
         pᵢ = cache_particle(coords, ip, idx)
 
-        if any(isinf, pᵢ)
+        if !isfinite(pᵢ[1]) || !isfinite(pᵢ[2])
             ## SOMEHOW THE PARTICLE DID ESCAPE THE DOMAIN
             ## => REMOVE IT
             @inbounds CAI.@index index[ip, idx] = false
@@ -45,12 +81,12 @@ function _move_particles!(coords, grid, dxi, index, idx)
         else
             # check whether the particle is
             # within the same cell and skip it
-            isincell(chop(pᵢ), corner_xi, dxi) && continue
+            isincell(pᵢ[1], corner_xi, dxi) && continue
 
             # new cell index
-            new_cell = cell_index(chop(pᵢ), grid, dxi)
+            new_cell = cell_index(pᵢ[1], grid, dxi)
 
-            if !(any(<(1), new_cell) || any(new_cell .≥ length(grid)))
+            if 1 ≤ new_cell < length(grid)
                 ## THE PARTICLE DID NOT ESCAPE THE DOMAIN
                 # remove particle from child cell
                 nan = convert(eltype(eltype(coords[1])), NaN)

--- a/src/MarkerChain/resample.jl
+++ b/src/MarkerChain/resample.jl
@@ -8,7 +8,7 @@ This keeps the marker spacing reasonably regular, which improves interpolation
 quality and the stability of subsequent marker-chain operations.
 """
 function resample!(chain::MarkerChain)
-    (; coords, index, cell_vertices, min_xcell, max_xcell) = chain
+    (; coords, index, cell_vertices, h_vertices, min_xcell, max_xcell) = chain
     nx = length(index)
     dx_cells = cell_length(chain)
 
@@ -16,19 +16,25 @@ function resample!(chain::MarkerChain)
     sort_chain!(chain)
 
     # call kernel
-    launch!(ka_backend(index), resample_kernel!, nx, coords, cell_vertices, index, min_xcell, max_xcell, dx_cells)
+    launch!(
+        ka_backend(index), resample_kernel!, nx,
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells
+    )
     return nothing
 end
 
 @kernel function resample_kernel!(
-        coords, cell_vertices, index, min_xcell, max_xcell, dx_cells
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells
     )
     i = @index(Global)
-    resample_cell!(coords, cell_vertices, index, min_xcell, max_xcell, dx_cells, i)
+    resample_cell!(
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells, i
+    )
 end
 
 function resample_cell!(
-        coords::NTuple{2, T}, cell_vertices, index, min_xcell, max_xcell, dx_cells, I
+        coords::NTuple{2, T}, cell_vertices, h_vertices, index,
+        min_xcell, max_xcell, dx_cells, I
     ) where {T}
 
     # cell particles coordinates
@@ -55,7 +61,12 @@ function resample_cell!(
             # x query point
             xq = cell_vertex + dx_chain * ip
             # interpolated y coordinated
-            yq = if 1 < I < length(index)
+            yq = if np < 2
+                _interp1D(
+                    xq, cell_vertices[I], cell_vertices[I + 1],
+                    h_vertices[I], h_vertices[I + 1]
+                )
+            elseif 1 < I < length(index)
                 # inner cells; this is true (ncells-2) consecutive times
                 interp1D_inner(xq, x_cell, y_cell, coords, I)
             else

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -117,17 +117,24 @@ struct MarkerChain{Backend, N, I, T1, T2, T3, TV} <: AbstractParticles
 end
 
 function MarkerChain(coords, index::CPUCellArray, cell_vertices, min_xcell, max_xcell)
-    return MarkerChain(
+    _uniform_grid_spacing(cell_vertices)
+    coords0 = deepcopy.(coords)
+    T = eltype(eltype(coords[1]))
+    h_vertices = zeros(T, length(cell_vertices))
+    chain = MarkerChain(
         CPU,
         coords,
         coords0,
         h_vertices,
-        h_vertices0,
+        copy(h_vertices),
         cell_vertices,
         index,
-        max_xcell,
         min_xcell,
+        max_xcell,
     )
+    compute_topography_vertex!(chain)
+    copyto!(chain.h_vertices0, chain.h_vertices)
+    return chain
 end
 
 """
@@ -164,6 +171,25 @@ end
 
 unwrap_abstractarray(x::AbstractArray) = typeof(x).name.wrapper
 
+function _uniform_grid_spacing(xv)
+    ncells = length(xv) - 1
+    ncells > 0 || throw(ArgumentError("cell_vertices must contain at least two vertices"))
+
+    spacings = diff(xv)
+    dx = sum(spacings) / ncells
+    T = typeof(dx)
+    min_spacing = minimum(spacings)
+    max_spacing = maximum(spacings)
+    tolerance = convert(T, 32) * eps(T) * max(abs(dx), abs(min_spacing), abs(max_spacing))
+
+    isfinite(dx) && min_spacing > zero(T) ||
+        throw(ArgumentError("MarkerChain cell_vertices must be finite and strictly increasing"))
+    maximum(abs.(spacings .- dx)) ≤ tolerance ||
+        throw(ArgumentError("MarkerChain requires uniformly spaced cell_vertices"))
+
+    return dx
+end
+
 @inline count_particles(p::AbstractParticles, icell::Vararg{Int, N}) where {N} =
     count(p.index[icell...])
 
@@ -173,8 +199,10 @@ unwrap_abstractarray(x::AbstractArray) = typeof(x).name.wrapper
 Return the horizontal cell size of a 2D marker chain.
 
 This is the spacing between consecutive entries in `chain.cell_vertices`.
+Marker chains require this grid to be uniformly spaced.
 """
-@inline cell_length(p::MarkerChain{B, 2}) where {B} = p.cell_vertices[2] - p.cell_vertices[1]
+@inline cell_length(p::MarkerChain{B, 2}) where {B} =
+    sum(diff(p.cell_vertices)) / (length(p.cell_vertices) - 1)
 @inline cell_length_x(p::MarkerChain{B, 3}) where {B} =
     p.cell_vertices[1][2] - p.cell_vertices[1][1]
 @inline cell_length_y(p::MarkerChain{B, 3}) where {B} =

--- a/test/test_markerchain_2D.jl
+++ b/test/test_markerchain_2D.jl
@@ -45,6 +45,7 @@ function host_chain(chain)
 end
 
 chain_tol(chain) = eltype(Array(chain.h_vertices)) <: Float32 ? 1.0f-5 : 1.0e-10
+chain_mean(h) = (sum(h) - (first(h) + last(h)) / 2) / (length(h) - 1)
 
 # set slot `ip` of cell `cell` without assuming the backend's CellArray data layout
 function set_cell_slot!(A, ip, cell, val)
@@ -126,6 +127,12 @@ end
         @test count(index) == nxcell * (length(xv_cpu) - 1)
         @test all(Array(chain.h_vertices) .≈ elevation)
         @test Array(chain.h_vertices0) == Array(chain.h_vertices)
+        @test chain.coords0[1].data !== chain.coords[1].data
+        @test chain.coords0[2].data !== chain.coords[2].data
+        previous_x = host_data(chain.coords0[1])
+        set_cell_slot!(chain.coords[1], 1, 1, px[1, 1] + eps(T))
+        @test isequal(host_data(chain.coords0[1]), previous_x)
+        set_cell_slot!(chain.coords[1], 1, 1, px[1, 1])
         assert_chain_invariants(chain)
 
         for i in axes(index, 2)
@@ -140,10 +147,24 @@ end
         _, py, index, _ = host_chain(chain)
         @test isapprox(Array(chain.h_vertices), topo_y; atol = chain_tol(chain), rtol = chain_tol(chain))
         for i in axes(index, 2)
-            @test all(py[1:nxcell, i] .≈ topo_y[i])
+            expected_y = range(topo_y[i], topo_y[i + 1]; length = nxcell + 2)[2:(end - 1)]
+            @test py[1:nxcell, i] ≈ expected_y
         end
+        compute_topography_vertex!(chain)
+        @test isapprox(Array(chain.h_vertices), topo_y; atol = chain_tol(chain), rtol = chain_tol(chain))
         assert_chain_invariants(chain)
     end
+
+    @static if BACKEND_NAME == "CPU"
+        xv = collect(range(0.0, 1.0; length = 6))
+        original = init_markerchain(CPU, 3, 2, 5, xv, 0.4)
+        reconstructed = MarkerChain(original.coords, original.index, xv, 2, 5)
+        @test Array(reconstructed.h_vertices) ≈ fill(0.4, length(xv))
+        @test reconstructed.coords0[1].data !== reconstructed.coords[1].data
+    end
+
+    nonuniform_xv = TA(backend)(FT[0, 0.2, 0.5, 1])
+    @test_throws ArgumentError init_markerchain(backend, 2, 1, 4, nonuniform_xv, FT(0.4))
 end
 
 @testset "MarkerChain topography reconstruction 2D" begin
@@ -169,7 +190,7 @@ end
 
     compute_topography_vertex!(chain)
     h_vertices = Array(chain.h_vertices)
-    @test isapprox(h_vertices[2:(end - 1)], topo_y[2:(end - 1)]; atol = chain_tol(chain), rtol = chain_tol(chain))
+    @test isapprox(h_vertices, topo_y; atol = chain_tol(chain), rtol = chain_tol(chain))
 end
 
 @testset "MarkerChain reconstruct non-contiguous index 2D" begin
@@ -194,6 +215,22 @@ end
     @test all(.!isnan.(py2[active2, 2]))
     @test all(cell_vertices[2] .< px2[active2, 2] .< cell_vertices[3])
     @test all(diff(px2[active2, 2]) .> 0)
+    assert_chain_invariants(chain)
+end
+
+@testset "MarkerChain multi-cell movement 2D" begin
+    xv_cpu = collect(range(FT(0), FT(1); length = 9))
+    chain = init_markerchain(backend, 1, 1, 4, TA(backend)(xv_cpu), FT(0.4))
+
+    # Two distant sources converge on cell 4. This exercises both arbitrary-distance
+    # jumps and collision-free destination writes on threaded/GPU backends.
+    set_cell_slot!(chain.coords[1], 1, 1, FT(0.4))
+    set_cell_slot!(chain.coords[1], 1, 7, FT(0.46))
+    move_particles!(chain)
+
+    _, _, index, _ = host_chain(chain)
+    @test count(index) == length(xv_cpu) - 1
+    @test active_counts(index) == [0, 1, 1, 3, 1, 1, 0, 1]
     assert_chain_invariants(chain)
 end
 
@@ -256,6 +293,19 @@ end
     @test active_counts(index) == fill(4, length(xv_cpu) - 1)
     assert_chain_invariants(chain)
     assert_markers_on_line(chain, a, b)
+
+    chain = init_markerchain(backend, 4, 2, 6, xv, FT(0.2))
+    for ip in 1:4
+        set_cell_slot!(chain.index, ip, 1, false)
+        set_cell_slot!(chain.coords[1], ip, 1, NaN)
+        set_cell_slot!(chain.coords[2], ip, 1, NaN)
+    end
+    resample!(chain)
+    px, py, index, _ = host_chain(chain)
+    @test count(index[:, 1]) == 2
+    @test all(isfinite, px[index])
+    @test all(isfinite, py[index])
+    assert_chain_invariants(chain)
 end
 
 @testset "MarkerChain advection 2D" begin
@@ -304,7 +354,21 @@ end
     h0 = copy(Array(chain.h_vertices))
     V = constant_markerchain_velocity(grid_vx, grid_vy, FT(0), vy)
     advect_markerchain!(chain, Euler(), V, grid_vi, dt)
-    @test mean(Array(chain.h_vertices)) ≈ mean(h0)
+    @test chain_mean(Array(chain.h_vertices)) ≈ chain_mean(h0)
+    assert_chain_invariants(chain)
+
+    profile = @. FT(0.35) + FT(0.08) * sin(FT(2pi) * xv) + FT(0.03) * xv^2
+    chain = init_markerchain(backend, 4, 2, 8, xv, FT(0))
+    fill_chain_from_vertices!(chain, TA(backend)(collect(profile)))
+    h0 = copy(Array(chain.h_vertices))
+    V0 = constant_markerchain_velocity(grid_vx, grid_vy, FT(0), FT(0))
+    for _ in 1:20
+        advect_markerchain!(chain, RungeKutta2(), V0, grid_vi, dt)
+    end
+    h = Array(chain.h_vertices)
+    tol = FT === Float32 ? 2.0f-4 : 1.0e-9
+    @test isapprox(h, h0; atol = tol, rtol = tol)
+    @test isapprox(chain_mean(h), chain_mean(h0); atol = tol, rtol = tol)
     assert_chain_invariants(chain)
 end
 
@@ -352,8 +416,34 @@ end
     chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, elevation)
     h0 = copy(Array(chain.h_vertices))
     semilagrangian_advection_markerchain!(chain, RungeKutta2(), Vup, grid_vi, grid, dt)
-    @test mean(Array(chain.h_vertices)) ≈ mean(h0)
+    @test chain_mean(Array(chain.h_vertices)) ≈ chain_mean(h0)
     assert_chain_invariants(chain)
+
+    slope = FT(0.1)
+    profile = @. FT(0.3) + slope * xv
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, FT(0))
+    fill_chain_from_vertices!(chain, TA(backend)(collect(profile)))
+    vx = FT(0.05)
+    Vright = constant_markerchain_velocity(grid_vx, grid_vy, vx, FT(0))
+    JustPIC.semilagrangian_advection!(chain, RungeKutta2(), Vright, grid_vi, grid, dt)
+    expected = @. profile - slope * vx * dt
+    @test isapprox(
+        Array(chain.h_vertices)[2:(end - 1)], expected[2:(end - 1)];
+        atol = (FT === Float32 ? 1.0f-5 : 1.0e-12), rtol = chain_tol(chain)
+    )
+
+    steep = fill(FT(0.4), length(xv))
+    steep[2] += FT(0.2)
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xv, FT(0))
+    fill_chain_from_vertices!(chain, TA(backend)(steep))
+    mean0 = chain_mean(steep)
+    semilagrangian_advection_markerchain!(
+        chain, RungeKutta2(), V0, grid_vi, grid, dt; max_slope_angle = 5
+    )
+    @test isapprox(
+        chain_mean(Array(chain.h_vertices)), mean0;
+        atol = (FT === Float32 ? 1.0f-5 : 1.0e-12), rtol = chain_tol(chain)
+    )
 
     # Float32 grid: the SL path must recast its grids/integrator and keep the topography
     # precision (guards against Float64 promotion, which breaks Metal)
@@ -395,7 +485,7 @@ end
     h = Array(chain.h_vertices)
     @test all(isfinite, h)
     @test all(h .≈ elevation)
-    @test mean(h) ≈ mean(h0)
+    @test chain_mean(h) ≈ chain_mean(h0)
     assert_chain_invariants(chain)
 end
 
@@ -455,6 +545,12 @@ end
         data = Array(field)
         @test all(0 .≤ data .≤ 1)
     end
+
+    topo = @. FT(0.25) + FT(0.3) * xv
+    copyto!(chain.h_vertices, TA(backend)(collect(topo)))
+    ratios = make_ratios()
+    compute_rock_fraction!(ratios, chain, xvi, dxi)
+    @test isapprox(Array(ratios.vertex)[2, 3], FT(0.8); atol = (FT === Float32 ? 1.0f-5 : 1.0e-12))
 end
 
 @testset "MarkerChain slope smoothing 2D" begin
@@ -508,4 +604,5 @@ end
     topo_x = [0.5, 1.5, 1.6, 2.5]
     cell_vertices = [0.0, 1.0, 2.0, 3.0]
     @test JustPIC.first_last_particle_incell(topo_x, cell_vertices, 2) == (2, 3)
+    @test JustPIC.first_last_particle_incell([0.1, 0.2], cell_vertices, 2) == (1, 0)
 end


### PR DESCRIPTION
## Summary

This PR fixes several related correctness issues in the marker-chain pipeline, with particular emphasis on conserving the mean height of the represented piecewise-linear surface.

It also hardens marker reconstruction, initialization, resampling, semi-Lagrangian transport, and cell reassignment on CPU and GPU backends.

## Mean-height conservation

The conserved quantity is now computed as the domain mean of the piecewise-linear vertex profile. On a uniform grid this is the trapezoidal mean, so the two endpoints receive half weight.

After advection or slope limiting, let the reconstructed mean be m and the previous mean be m0. The correction remains:

    h <- h - (m - m0)

The sign is intentional and correct because the corrected mean is:

    m - (m - m0) = m0

The tests exercise the sign directionally: a positive uniform vertical velocity raises the raw semi-Lagrangian result by vy*dt, while the conserving wrapper restores the previous mean.

## Correctness fixes

- Compute mean height using the trapezoidal mean of the piecewise-linear chain rather than the arithmetic mean of all vertices.
- Reconstruct vertex heights from adjacent per-cell linear fits so reconstruction is an exact fixed point for stationary linear and nonlinear profiles.
- Sample the old topography at the horizontal departure coordinate during semi-Lagrangian backtracking.
- Preserve the mean after slope limiting using the same piecewise-linear mean definition.
- Use cached vertex segments when resampling cells containing zero or one marker.
- Fix the vertical-index lookup in marker-chain rock-fraction calculations.
- Allocate independent previous-coordinate buffers instead of aliasing current coordinates.
- Interpolate vector-valued initial elevations within each cell and validate elevation lengths and marker-count bounds.
- Correct empty-cell detection while filling a chain from an input polyline.
- Repair the legacy CPU MarkerChain constructor and initialize its cached topography consistently.

## Grid contract

Marker-chain lookup and resampling assume a constant horizontal cell width. Construction now validates that cell vertices are finite, strictly increasing, and uniformly spaced, and the requirement is documented in the marker-chain guide.

The validation uses backend-compatible reductions, so dense CUDA grid arrays are supported without host scalar indexing.

## Arbitrary cell crossings

The old movement scheduling was only safe when a marker crossed at most one cell per call. The new implementation:

1. Computes the maximum active marker-cell jump on the backend.
2. Uses 2J+1 source colors for a maximum jump J.
3. Processes each color synchronously.

Sources within a color are farther apart than their possible destination intervals, preventing concurrent writes to the same destination even for multi-cell jumps. Non-finite markers are removed consistently.

A regression sends two distant source cells into the same destination cell, covering the race on CUDA as well as CPU.

## Tests

Passed locally:

- JULIA_JUSTPIC_BACKEND=CPU julia --project=. --startup-file=no test/test_markerchain_2D.jl
- JULIA_JUSTPIC_BACKEND=CPU JULIA_JUSTPIC_PRECISION=Float32 julia --project=. --startup-file=no test/test_markerchain_2D.jl
- julia --project=. --startup-file=no -e using-Pkg-Pkg.test-with-CUDA (full official CUDA package suite)
- Runic formatting check for every changed Julia file
- git diff --check

The CUDA run covered the complete 2D, 3D, CellArray, interpolation, marker-chain, and save/load suites.

## Documentation

The marker-chain guide now states the uniform-grid requirement. A local Documenter build was not available because the docs environment dependencies were not installed; no dependency or manifest changes are included in this PR.