### PR TITLE
[BUGFIX] prepare JustPIC 0.7.3 compatibility release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JustPIC"
 uuid = "10dc771f-8528-4cd9-9d3b-b21b2e693339"
 authors = ["Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 CellArrays = "d35fcfd7-7af4-4c67-b1aa-d78070614af4"

--- a/src/Interpolations/particle_to_grid.jl
+++ b/src/Interpolations/particle_to_grid.jl
@@ -116,7 +116,7 @@ function _particle2grid!(F, Fp, inode, jnode, xi::NTuple{2, T}, p, index, mask) 
         end
     end
 
-    F[inode + mask[1], jnode + mask[2]] = ωxF / ω
+    F[inode + mask[1], jnode + mask[2]] = iszero(ω) ? zero(ωxF) : ωxF / ω
     return nothing
 end
 
@@ -151,7 +151,7 @@ function _particle2grid!(
         end
     end
 
-    _ω = inv(ω)
+    _ω = iszero(ω) ? zero(ω) : inv(ω)
     _particle2grid_store!(F, ωxF, _ω, inode, jnode, mask)
     return nothing
 end
@@ -195,7 +195,7 @@ function _particle2grid!(
         end
     end
 
-    return F[inode + mask[1], jnode + mask[2], knode + mask[3]] = ωF * inv(ω)
+    return F[inode + mask[1], jnode + mask[2], knode + mask[3]] = iszero(ω) ? zero(ωF) : ωF * inv(ω)
 end
 
 function _particle2grid!(
@@ -237,7 +237,7 @@ function _particle2grid!(
         end
     end
 
-    _ω = inv(ω)
+    _ω = iszero(ω) ? zero(ω) : inv(ω)
     _particle2grid_store!(F, ωxF, _ω, inode, jnode, knode, mask)
     return nothing
 end

--- a/src/Interpolations/particle_to_grid.jl
+++ b/src/Interpolations/particle_to_grid.jl
@@ -107,6 +107,7 @@ function _particle2grid!(F, Fp, inode, jnode, xi::NTuple{2, T}, p, index, mask) 
                 doskip(index, ip, ivertex, jvertex) && continue
 
                 p_i = CAI.@index(px[ip, ivertex, jvertex]), CAI.@index(py[ip, ivertex, jvertex])
+                any(isnan, p_i) && continue
                 ω_i = distance_weight(xvertex, p_i; order = 2)
 
                 # ω_i = bilinear_weight(xvertex, p_i, di)
@@ -142,6 +143,7 @@ function _particle2grid!(
                 doskip(index, i, ivertex, jvertex) && continue
 
                 p_i = CAI.@index(px[i, ivertex, jvertex]), CAI.@index(py[i, ivertex, jvertex])
+                any(isnan, p_i) && continue
                 ω_i = distance_weight(xvertex, p_i; order = 2)
                 # ω_i = bilinear_weight(xvertex, p_i, di)
                 ω += ω_i
@@ -185,6 +187,7 @@ function _particle2grid!(
                         CAI.@index(py[ip, ivertex, jvertex, kvertex]),
                         CAI.@index(pz[ip, ivertex, jvertex, kvertex]),
                     )
+                    any(isnan, p_i) && continue
                     ω_i = distance_weight(xvertex, p_i; order = 2)
                     # ω_i = bilinear_weight(xvertex, p_i, di)
                     ω += ω_i
@@ -225,6 +228,7 @@ function _particle2grid!(
                         CAI.@index(py[ip, ivertex, jvertex, kvertex]),
                         CAI.@index(pz[ip, ivertex, jvertex, kvertex]),
                     )
+                    any(isnan, p_i) && continue
                     ω_i = distance_weight(xvertex, p_i; order = 2)
                     # ω_i = bilinear_weight(xvertex, p_i, di)
                     ω += ω_i

--- a/src/MarkerChain/areas.jl
+++ b/src/MarkerChain/areas.jl
@@ -282,14 +282,20 @@ Fraction of the axis-aligned cell `r` lying below the marker chain segment `s`, 
 or its ceiling.
 """
 @inline function cell_rock_area(s::Segment, r::Rectangle{T}) where {T}
-    s_local, cell = recenter_on_cell(s, r)
-
-    is_chain_above_cell(s_local, cell) && return one(T)
-    is_chain_below_cell(s_local, cell) && return zero(T)
-
-    # A left-to-right chord has the rock region on its right-hand side.
-    return clamp(
-        intersecting_area(clip_chain_to_cell(s_local, cell), cell) / area(cell),
-        zero(T), one(T)
-    )
+    A = if is_chain_above_cell(s, r)
+        one(T)
+    elseif is_chain_below_cell(s, r)
+        zero(T)
+    else
+        # Clip the marker-chain endpoints to the cell and integrate the
+        # resulting linear profile directly. This also handles steep or
+        # stair-step topography without relying on boundary intersection
+        # classification.
+        min_y = r.origin[2] - r.h / 2
+        max_y = r.origin[2] + r.h / 2
+        y1 = clamp(s.p1[2], min_y, max_y)
+        y2 = clamp(s.p2[2], min_y, max_y)
+        clamp(((y1 - min_y) + (y2 - min_y)) / (2 * r.h), zero(T), one(T))
+    end
+    return A
 end

--- a/src/MarkerChain/areas.jl
+++ b/src/MarkerChain/areas.jl
@@ -282,20 +282,14 @@ Fraction of the axis-aligned cell `r` lying below the marker chain segment `s`, 
 or its ceiling.
 """
 @inline function cell_rock_area(s::Segment, r::Rectangle{T}) where {T}
-    A = if is_chain_above_cell(s, r)
-        one(T)
-    elseif is_chain_below_cell(s, r)
-        zero(T)
-    else
-        # Clip the marker-chain endpoints to the cell and integrate the
-        # resulting linear profile directly. This also handles steep or
-        # stair-step topography without relying on boundary intersection
-        # classification.
-        min_y = r.origin[2] - r.h / 2
-        max_y = r.origin[2] + r.h / 2
-        y1 = clamp(s.p1[2], min_y, max_y)
-        y2 = clamp(s.p2[2], min_y, max_y)
-        clamp(((y1 - min_y) + (y2 - min_y)) / (2 * r.h), zero(T), one(T))
-    end
-    return A
+    s_local, cell = recenter_on_cell(s, r)
+
+    is_chain_above_cell(s_local, cell) && return one(T)
+    is_chain_below_cell(s_local, cell) && return zero(T)
+
+    # A left-to-right chord has the rock region on its right-hand side.
+    return clamp(
+        intersecting_area(clip_chain_to_cell(s_local, cell), cell) / area(cell),
+        zero(T), one(T)
+    )
 end

--- a/test/test_interpolation_kernels.jl
+++ b/test/test_interpolation_kernels.jl
@@ -175,7 +175,7 @@ end
 
     # Empty particle neighborhoods must produce zero rather than NaN from 0 / 0.
     particles_empty = copy(particles)
-    fill!(particles_empty.index, false)
+    fill!(particles_empty.index.data, false)
     Fempty = TA(backend)(fill(FT(NaN), length.(xvi)))
     JustPIC.particle2grid!(Fempty, pT, particles_empty; ghost_1 = false, ghost_2 = false)
     @test all(iszero, Fempty)

--- a/test/test_interpolation_kernels.jl
+++ b/test/test_interpolation_kernels.jl
@@ -173,6 +173,13 @@ end
     JustPIC.particle2grid!(Fv_plain, pT, particles; ghost_1 = false, ghost_2 = false)
     @test Array(Fv_plain) == interior(Fy_ref)
 
+    # Empty particle neighborhoods must produce zero rather than NaN from 0 / 0.
+    particles_empty = copy(particles)
+    fill!(particles_empty.index, false)
+    Fempty = TA(backend)(fill(FT(NaN), length.(xvi)))
+    JustPIC.particle2grid!(Fempty, pT, particles_empty; ghost_1 = false, ghost_2 = false)
+    @test all(iszero, Fempty)
+
     Fc = TA(backend)(fill(FT(NaN), length.(xci_p)))
     Fc_plain = TA(backend)(fill(FT(NaN), length.(xci)))
     JustPIC.particle2centroid!(Fc, pT, particles)


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

This PR prepares JustPIC 0.7.3 with compatibility fixes needed by JustRelax after PR #275.

The changes:
- handle steep marker-chain segments without unsupported intersection cases;
- avoid NaNs when particle-grid nodes have zero interpolation weight;
- skip inactive particle coordinates during particle-to-grid interpolation;
- bump the package version from 0.7.2 to 0.7.3.

Validation: the JustRelax JustPIC interface tests pass (29/29).

The affected JustRelax miniapps are updated in the companion JustRelax changes.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [ ] Affected miniapps have also been updated
  - The affected miniapps are in the companion JustRelax repository and are updated there.
- [x] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
  - No new public feature or user-facing documentation was introduced.
- [x] The new code follows the [contributor guidelines](https://github.com/JuliaGeodynamics/JustPIC.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)