### PR TITLE
[ADDITION] Non-uniformly spaced grids for MarkerChain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JustPIC"
 uuid = "10dc771f-8528-4cd9-9d3b-b21b2e693339"
 authors = ["Albert De Montserrat <albertdemontserratnavarro@erdw.ethz.ch>"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 CellArrays = "d35fcfd7-7af4-4c67-b1aa-d78070614af4"

--- a/docs/src/marker_chain.md
+++ b/docs/src/marker_chain.md
@@ -28,9 +28,12 @@ vertices (`h_vertices`). The most useful fields are:
 Marker precision follows the grid/elevation element type, so a `Float32` grid produces a
 `Float32` chain — this is required on Metal, which has no `Float64`.
 
-`cell_vertices` must be finite, strictly increasing, and uniformly spaced. Marker lookup,
-resampling, and movement use one constant cell width; construction throws an
-`ArgumentError` when this grid contract is violated.
+`cell_vertices` must be finite and strictly increasing; construction throws an
+`ArgumentError` otherwise. The spacing is free: a refined (non-uniformly spaced) grid is
+supported, and marker lookup, resampling and movement all resolve each column's width from
+its own pair of vertices. `cell_length(chain, i)` returns that width. The one-argument
+`cell_length(chain)` returns the single width shared by every column and therefore throws
+on a refined grid.
 
 ## Creating a chain
 
@@ -114,7 +117,9 @@ compute_rock_fraction!(ratios, chain, xvi, dxi)
 
 `ratios` is a container with `center`, `vertex`, `Vx`, and `Vy` fields (e.g. a `PhaseRatios`
 or a named tuple of arrays) sized to the respective grid locations; each is filled with a
-value in `[0, 1]`. `xvi` is the vertex grid and `dxi` the grid spacing.
+value in `[0, 1]`. `xvi` is the vertex grid and `dxi` the matching spacing: one `Number`
+per direction on a uniform grid, or one vector of per-cell widths per direction on a
+refined one.
 
 You can also interpolate the grid velocity onto the current marker positions (for diagnostics
 or custom advection) with `interpolate_velocity_to_markerchain!(chain, chain_V, V, grid_vxi)`,
@@ -180,13 +185,44 @@ scatter!(px, py, color = :black)
 display(f)
 ```
 
+### Refined grid
+
+The same example runs on a graded horizontal grid — only the construction of `xv`/`yv`
+changes. A non-range grid is indexed directly inside the kernels, so on a GPU backend it has
+to be moved to the device with `TA(backend)`:
+
+```julia
+# cell widths growing left to right by a factor of 4
+function graded(n, L)
+    widths = [1 + 3 * (i - 1) / (n - 2) for i in 1:(n - 1)]
+    x = cumsum(vcat(0.0, widths))
+    return L .* x ./ last(x)
+end
+
+expand_vector(x) = vcat(x[1] - (x[2] - x[1]), x, x[end] + (x[end] - x[end - 1]))
+
+xv, yv = graded(n, Lx), graded(n, Ly)
+xc = (xv[1:(end - 1)] .+ xv[2:end]) ./ 2
+yc = (yv[1:(end - 1)] .+ yv[2:end]) ./ 2
+
+grid_vx = TA(backend)(xv), TA(backend)(expand_vector(yc))
+grid_vy = TA(backend)(expand_vector(xc)), TA(backend)(yv)
+grid_vxi = grid_vx, grid_vy
+
+chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv), initial_elevation)
+```
+
+The time-stepping loop is unchanged. Where a uniform grid passes a scalar `dxi` to
+`compute_rock_fraction!`, a refined one passes the per-cell widths: `dxi = diff(xv), diff(yv)`.
+
 The `scripts/rotating_marker_chain*.jl` files in the repository provide runnable Lagrangian
-and semi-Lagrangian variants of this example.
+and semi-Lagrangian variants of this example, each with a `*_refined.jl` sibling.
 
 ## API
 
 ```@docs
 MarkerChain
+cell_length
 init_markerchain
 fill_chain_from_chain!
 fill_chain_from_vertices!

--- a/scripts/refined_grid_utils.jl
+++ b/scripts/refined_grid_utils.jl
@@ -1,0 +1,98 @@
+# Helpers for building graded (non-uniformly spaced) coordinate grids.
+
+"""
+    expand_range(x::AbstractVector)
+
+Extend a coordinate vector by one node on each side, preserving the spacing of the first
+and last cells. Used to build the ghost-node rows of a staggered velocity grid.
+"""
+function expand_range(x::AbstractVector)
+    dx_left = x[2] - x[1]
+    dx_right = x[end] - x[end - 1]
+    return vcat(x[1] - dx_left, x, x[end] + dx_right)
+end
+
+"""
+    checkGridLength(n, d0, f)
+
+Total length spanned by `n` cells whose widths grow geometrically from `d0` by the factor
+`f`.
+"""
+function checkGridLength(n, d0, f)
+    if f < 1
+        error("Growth factor cannot be smaller than 1!")
+    elseif isone(f)
+        return n * d0
+    else
+        return d0 * (f^n - 1) / (f - 1)
+    end
+end
+
+"""
+    findGrowthFactor(L, n, d0)
+
+Growth factor for which `n` geometrically graded cells starting at width `d0` span `L`,
+found by bisection.
+"""
+function findGrowthFactor(L, n, d0)
+    a = 1.0
+    b = 2.0
+    for i in 1:20
+        c = (a + b) / 2.0
+        err = checkGridLength(n, d0, c) - L
+        if abs(err) < L / 1.0e3
+            return c
+        elseif err > 0
+            b = c
+        else
+            a = c
+        end
+    end
+    return error("No growth factor spans L = $L with $n cells of minimum width $d0")
+end
+
+"""
+    makeExpoGrid(L, n, d0, x0)
+
+Build a grid of `n` cells spanning `[x0, x0 + L]`, refined to width `d0` at the center and
+coarsening geometrically towards both ends.
+
+Returns `(xn, xc, dx)`: the `n + 1` vertices, the `n` cell centers, and the `n` cell widths.
+"""
+function makeExpoGrid(L, n, d0, x0)
+    dx = zeros(n)
+    if mod(n, 2) == 0
+        L2 = L / 2.0
+        n2 = Int64(n / 2)
+        f = findGrowthFactor(L2, n2, d0)
+        dx[n2:(n2 + 1)] .= d0
+        dn = 2
+    else
+        L2 = L / 2.0 + d0 / 2.0
+        n2 = Int64((n + 1) / 2)
+        f = findGrowthFactor(L2, n2, d0)
+        dx[n2] = d0
+        dn = 1
+    end
+    for i in (n2 + dn):(n - 1)
+        dx[i] = dx[i - 1] * f
+    end
+    for i in (n2 - 1):-1:2
+        dx[i] = dx[i + 1] * f
+    end
+
+    dx[1] = (L - sum(dx)) / 2.0
+    dx[end] = dx[1]
+
+    xn = zeros(n + 1)
+    xc = zeros(n + 2) # with ghost cells
+    xn[1] = x0
+    xc[1] = x0 - dx[1] / 2.0
+    xc[end] = x0 + L + dx[end] / 2.0
+    for i in 1:n
+        xn[i + 1] = xn[i] + dx[i]
+        xc[i + 1] = (xn[i] + xn[i + 1]) / 2.0
+    end
+
+    return xn, xc[2:(end - 1)], dx
+end

--- a/scripts/rotating_marker_chain_SML_refined.jl
+++ b/scripts/rotating_marker_chain_SML_refined.jl
@@ -1,0 +1,61 @@
+using JustPIC
+using GLMakie
+
+const backend = JustPIC.CPU
+
+include(joinpath(@__DIR__, "refined_grid_utils.jl"))
+
+# Analytical flow solution
+vi_stream(x) = π * 1.0e-5 * (x - 0.5)
+
+function main()
+
+    # Initialize particles -------------------------------
+    n = 51
+    nx = ny = n - 1
+    Lx = Ly = 1.0
+    # graded nodal vertices, five times finer at the center than a uniform grid would be
+    xv, xc, dx = makeExpoGrid(Lx, nx, Lx / nx / 5, 0.0)
+    yv, yc, dy = makeExpoGrid(Ly, ny, Ly / ny / 5, 0.0)
+    # staggered grid velocity nodal locations
+    yv_vx = expand_range(yc)
+    xv_vy = expand_range(xc)
+
+    # a refined grid is indexed directly inside the kernels, so it lives on the device
+    xvi = TA(backend)(xv), TA(backend)(yv)
+    grid_vx = TA(backend)(xv), TA(backend)(yv_vx)
+    grid_vy = TA(backend)(xv_vy), TA(backend)(yv)
+    grid_vxi = grid_vx, grid_vy
+
+    # Cell fields -------------------------------
+    Vx = TA(backend)([-vi_stream(y) for x in xv, y in yv_vx])
+    Vy = TA(backend)([ vi_stream(x) for x in xv_vy, y in yv])
+    V = Vx, Vy
+
+    dt = 200.0
+
+    nxcell, min_xcell, max_xcell = 12, 6, 24
+    initial_elevation = Ly / 2
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xvi[1], initial_elevation)
+    chain.h_vertices .= initial_elevation
+    method = RungeKutta4()
+
+    for _ in 1:125
+        semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt)
+    end
+
+    f = Figure(size = (1200, 1200))
+    ax = Axis(f[1, 1])
+    # vector of shapes
+    poly!(
+        ax,
+        Rect(0, 0, 1, 1),
+        color = :lightgray,
+    )
+    vlines!(ax, xv, color = (:gray, 0.5))
+    lines!(ax, xv, Array(chain.h_vertices), color = :blue, linewidth = 4)
+    display(f)
+    return nothing
+end
+
+main()

--- a/scripts/rotating_marker_chain_SML_topography_refined.jl
+++ b/scripts/rotating_marker_chain_SML_topography_refined.jl
@@ -1,0 +1,69 @@
+using JustPIC
+using GLMakie
+
+const backend = JustPIC.CPU
+
+include(joinpath(@__DIR__, "refined_grid_utils.jl"))
+
+# Analytical flow solution
+vi_stream(x) = π * 1.0e-5 * (x - 0.5)
+
+function main()
+
+    # Initialize particles -------------------------------
+    n = 51
+    nx = ny = n - 1
+    Lx = Ly = 1.0
+    # graded nodal vertices, five times finer at the center than a uniform grid would be;
+    # the refinement sits where the volcano does, so slope limiting sees strongly varying dx
+    xv, xc, dx = makeExpoGrid(Lx, nx, Lx / nx / 5, 0.0)
+    yv, yc, dy = makeExpoGrid(Ly, ny, Ly / ny / 5, 0.0)
+    # staggered grid velocity nodal locations
+    yv_vx = expand_range(yc)
+    xv_vy = expand_range(xc)
+
+    # a refined grid is indexed directly inside the kernels, so it lives on the device
+    xvi = TA(backend)(xv), TA(backend)(yv)
+    grid_vx = TA(backend)(xv), TA(backend)(yv_vx)
+    grid_vy = TA(backend)(xv_vy), TA(backend)(yv)
+    grid_vxi = grid_vx, grid_vy
+
+    # Cell fields -------------------------------
+    Vx = TA(backend)([-vi_stream(y) for x in xv, y in yv_vx])
+    Vy = TA(backend)([ vi_stream(x) for x in xv_vy, y in yv])
+    V = Vx, Vy
+
+    dt = 200.0
+
+    nxcell, min_xcell, max_xcell = 12, 6, 24
+    initial_elevation = Ly / 2
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xvi[1], initial_elevation)
+
+    # Gaussian elevation to mimic a volcano
+    volcano_center = 0.5
+    volcano_height = 0.5
+    volcano_width = 0.1
+    gaussian_elevation = volcano_height .* exp.(-((xv .- volcano_center) .^ 2) ./ (2 * volcano_width^2))
+    steep_topography = TA(backend)(Ly / 2 .+ gaussian_elevation)
+    fill_chain_from_vertices!(chain, steep_topography)
+    method = RungeKutta4()
+
+    for _ in 1:125
+        semilagrangian_advection_markerchain!(chain, method, V, grid_vxi, xvi, dt; max_slope_angle = 45.0)
+    end
+
+    f = Figure(size = (1200, 1200))
+    ax = Axis(f[1, 1])
+    # vector of shapes
+    poly!(
+        ax,
+        Rect(0, 0, 1, 1),
+        color = :lightgray,
+    )
+    vlines!(ax, xv, color = (:gray, 0.5))
+    lines!(ax, xv, Array(chain.h_vertices), color = :blue, linewidth = 4)
+    display(f)
+    return nothing
+end
+
+main()

--- a/scripts/rotating_marker_chain_refined.jl
+++ b/scripts/rotating_marker_chain_refined.jl
@@ -1,0 +1,62 @@
+using JustPIC
+using GLMakie
+
+const backend = JustPIC.CPU
+
+include(joinpath(@__DIR__, "refined_grid_utils.jl"))
+
+# Analytical flow solution
+vi_stream(x) = π * 1.0e-5 * (x - 0.5)
+
+function main()
+
+    # Initialize particles -------------------------------
+    n = 51
+    nx = ny = n - 1
+    Lx = Ly = 1.0
+    # graded nodal vertices, five times finer at the center than a uniform grid would be
+    xv, xc, dx = makeExpoGrid(Lx, nx, Lx / nx / 5, 0.0)
+    yv, yc, dy = makeExpoGrid(Ly, ny, Ly / ny / 5, 0.0)
+    # staggered grid velocity nodal locations
+    yv_vx = expand_range(yc)
+    xv_vy = expand_range(xc)
+
+    # a refined grid is indexed directly inside the kernels, so it lives on the device
+    xvi = TA(backend)(xv), TA(backend)(yv)
+    grid_vx = TA(backend)(xv), TA(backend)(yv_vx)
+    grid_vy = TA(backend)(xv_vy), TA(backend)(yv)
+    grid_vxi = grid_vx, grid_vy
+
+    # Cell fields -------------------------------
+    Vx = TA(backend)([-vi_stream(y) for x in xv, y in yv_vx])
+    Vy = TA(backend)([ vi_stream(x) for x in xv_vy, y in yv])
+    V = Vx, Vy
+
+    dt = 200.0
+
+    nxcell, min_xcell, max_xcell = 12, 6, 24
+    initial_elevation = Ly / 2
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, xvi[1], initial_elevation)
+    method = RungeKutta2()
+
+    for _ in 1:25
+        advect_markerchain!(chain, method, V, grid_vxi, dt)
+    end
+
+    f = Figure()
+    ax = Axis(f[1, 1])
+    # vector of shapes
+    poly!(
+        ax,
+        Rect(0, 0, 1, 1),
+        color = :lightgray,
+    )
+    vlines!(ax, xv, color = (:gray, 0.5))
+    px = chain.coords[1].data[:]
+    py = chain.coords[2].data[:]
+    scatter!(px, py, color = :black)
+    return display(f)
+
+end
+
+main()

--- a/src/MarkerChain/Advection/Euler.jl
+++ b/src/MarkerChain/Advection/Euler.jl
@@ -4,12 +4,12 @@
         V::NTuple{N, AbstractArray{T, N}},
         grid_vi,
         local_limits,
-        dxi,
         dt,
+        icell,
     ) where {T, N}
 
     # interpolate velocity to current location
-    vp0 = interp_velocity2particle_markerchain(p0, grid_vi, local_limits, dxi, V)
+    vp0 = interp_velocity2particle_markerchain(p0, grid_vi, local_limits, V, icell)
 
     # first advection stage x = x + v * dt
     p1 = first_stage(method, dt, vp0, p0)

--- a/src/MarkerChain/Advection/RK2.jl
+++ b/src/MarkerChain/Advection/RK2.jl
@@ -4,19 +4,19 @@
         V::NTuple{N, AbstractArray{T, N}},
         grid_vi,
         local_limits,
-        dxi,
-        dt;
+        dt,
+        icell;
         backtracking::Bool = false
     ) where {T, N}
 
     # interpolate velocity to current location
-    vp0 = interp_velocity2particle_markerchain(p0, grid_vi, dxi, V)
+    vp0 = interp_velocity2particle_markerchain(p0, grid_vi, V, icell)
 
     # first advection stage x = x + v * dt * α
     p1 = first_stage(method, dt, vp0, p0; backtracking = backtracking)
 
     # interpolate velocity to new location
-    vp1 = interp_velocity2particle_markerchain(p1, grid_vi, dxi, V)
+    vp1 = interp_velocity2particle_markerchain(p1, grid_vi, V, icell)
 
     # final advection step
     p2 = second_stage(method, dt, vp0, vp1, p0; backtracking = backtracking)

--- a/src/MarkerChain/Advection/RK4.jl
+++ b/src/MarkerChain/Advection/RK4.jl
@@ -4,15 +4,15 @@
         V::NTuple{N, AbstractArray{T, N}},
         grid_vi,
         local_limits,
-        dxi,
-        dt;
+        dt,
+        icell;
         backtracking::Bool = false
     ) where {N, T}
     backtracking_sign = 1 - 2 * backtracking # flip sign if backtracking is true, used for backtracking particles during Semi-Lagrangian advection
-    k1 = interp_velocity2particle_markerchain(p0, grid_vi, dxi, V)
-    k2 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k1 ./ 2, grid_vi, dxi, V)
-    k3 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k2 ./ 2, grid_vi, dxi, V)
-    k4 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k3, grid_vi, dxi, V)
+    k1 = interp_velocity2particle_markerchain(p0, grid_vi, V, icell)
+    k2 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k1 ./ 2, grid_vi, V, icell)
+    k3 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k2 ./ 2, grid_vi, V, icell)
+    k4 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k3, grid_vi, V, icell)
 
     p = @. p0 + backtracking_sign * dt * (k1 + 2 * k2 + 2 * k3 + k4) / 6
     return p

--- a/src/MarkerChain/Advection/RK4.jl
+++ b/src/MarkerChain/Advection/RK4.jl
@@ -10,10 +10,22 @@
     ) where {N, T}
     backtracking_sign = 1 - 2 * backtracking # flip sign if backtracking is true, used for backtracking particles during Semi-Lagrangian advection
     k1 = interp_velocity2particle_markerchain(p0, grid_vi, V, icell)
-    k2 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k1 ./ 2, grid_vi, V, icell)
-    k3 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k2 ./ 2, grid_vi, V, icell)
-    k4 = interp_velocity2particle_markerchain(p0 .+ backtracking_sign .* dt .* k3, grid_vi, V, icell)
+    half_step = backtracking_sign * dt / 2
+    p1 = ntuple(Val(N)) do i
+        p0[i] + half_step * k1[i]
+    end
+    k2 = interp_velocity2particle_markerchain(p1, grid_vi, V, icell)
+    p2 = ntuple(Val(N)) do i
+        p0[i] + half_step * k2[i]
+    end
+    k3 = interp_velocity2particle_markerchain(p2, grid_vi, V, icell)
+    p3 = ntuple(Val(N)) do i
+        p0[i] + backtracking_sign * dt * k3[i]
+    end
+    k4 = interp_velocity2particle_markerchain(p3, grid_vi, V, icell)
 
-    p = @. p0 + backtracking_sign * dt * (k1 + 2 * k2 + 2 * k3 + k4) / 6
+    p = ntuple(Val(N)) do i
+        p0[i] + backtracking_sign * dt * (k1[i] + 2 * k2[i] + 2 * k3[i] + k4[i]) / 6
+    end
     return p
 end

--- a/src/MarkerChain/Advection/advection.jl
+++ b/src/MarkerChain/Advection/advection.jl
@@ -50,24 +50,24 @@ function advection!(
     ) where {N, T}
     (; coords, index) = chain
 
-    # recast integrator/timestep/grid to the marker precision (see particle
-    # advection!); `recast_grid` also makes the grid ranges GPU-safe on Float32
-    # backends (they are indexed directly inside the kernel)
+    # recast integrator/timestep/grid to the marker precision (see particle advection!);
+    # `backend_grid` also makes the grid GPU-safe -- it is indexed directly inside the
+    # kernel, so ranges are rebuilt Float32-safe and refined grids are moved to the device
     Tc = eltype(eltype(coords[1]))
+    backend = ka_backend(chain)
     method = set_precision(method, Tc)
     dt = convert(Tc, dt)
-    grid_vi = recast_grid(grid_vi, Tc)
+    grid_vi = backend_grid(backend, grid_vi, Tc)
 
     # compute some basic stuff
     ni = size(index, 1)
-    dxi = compute_dx(first(grid_vi))
 
     local_limits = inner_limits(grid_vi)
 
     # launch parallel advection kernel
     launch!(
-        ka_backend(chain), advection_markerchain_kernel!, ni,
-        coords, method, V, index, grid_vi, local_limits, dxi, dt
+        backend, advection_markerchain_kernel!, ni,
+        coords, method, V, index, grid_vi, local_limits, dt
     )
     return nothing
 end
@@ -82,7 +82,6 @@ end
         index,
         grid,
         local_limits,
-        dxi,
         dt,
     ) where {N, T}
     i = @index(Global)
@@ -93,7 +92,7 @@ end
         # extract particle coordinates
         pᵢ = get_particle_coords(p, ipart, i)
         # advect particle
-        pᵢ_new = advect_particle_markerchain(method, pᵢ, V, grid, local_limits, dxi, dt)
+        pᵢ_new = advect_particle_markerchain(method, pᵢ, V, grid, local_limits, dt, i)
         # update particle coordinates
         for k in 1:N
             @inbounds CAI.@index p[k][ipart, i] = pᵢ_new[k]
@@ -102,13 +101,13 @@ end
 end
 
 @inline function interp_velocity2particle_markerchain(
-        particle_coords::NTuple{N, Any}, grid_vi, local_limits, dxi, V::NTuple{N, Any}
+        particle_coords::NTuple{N, Any}, grid_vi, local_limits, V::NTuple{N, Any}, icell
     ) where {N}
     return ntuple(Val(N)) do i
         Base.@_inline_meta
         local_lims = local_limits[i]
         v = if check_local_limits(local_lims, particle_coords)
-            interp_velocity_grid2particle(particle_coords, grid_vi[i], dxi, V[i])
+            interp_velocity_grid2particle(particle_coords, grid_vi[i], V[i], icell)
         else
             # Typed sentinel: a bare `Inf` is Float64 and widens the tuple eltype,
             # which forces heap allocation inside the kernel (fatal on Metal).
@@ -118,20 +117,20 @@ end
 end
 
 @inline function interp_velocity2particle_markerchain(
-        particle_coords::NTuple{N, Any}, grid_vi, dxi, V::NTuple{N, Any}
+        particle_coords::NTuple{N, Any}, grid_vi, V::NTuple{N, Any}, icell
     ) where {N}
     return ntuple(Val(N)) do i
         Base.@_inline_meta
-        interp_velocity_grid2particle(particle_coords, grid_vi[i], dxi, V[i])
+        interp_velocity_grid2particle(particle_coords, grid_vi[i], V[i], icell)
     end
 end
 
 # Interpolate velocity from staggered grid to particle
 @inline function interp_velocity_grid2particle(
-        pᵢ::Union{SVector, NTuple}, xi_vx::NTuple, dxi::NTuple, F::AbstractArray
+        pᵢ::Union{SVector, NTuple}, xi_vx::NTuple, F::AbstractArray, icell
     )
-    # F and coordinates at/of the cell corners
-    Fi, x_vertex_cell = corner_field_nodes_MC(F, pᵢ, xi_vx, dxi)
+    # F, coordinates and spacing of the cell corners
+    Fi, x_vertex_cell, dxi = corner_field_nodes_MC(F, pᵢ, xi_vx, icell)
     # normalize particle coordinates
     ti = normalize_coordinates(pᵢ, x_vertex_cell, dxi)
     # Interpolate field F onto particle
@@ -139,14 +138,19 @@ end
     return Fp
 end
 
-# Get field F and nodal indices of the cell corners where the particle is located
-@inline function corner_field_nodes_MC(F::AbstractArray{T, N}, pᵢ, xi_vx, dxi) where {T, N}
+# Get field F, and the coordinates and widths of the cell where the particle is located.
+# The widths are read off `xi_vx` per direction and per cell, so a staggered grid whose
+# components are refined differently is handled by construction.
+@inline function corner_field_nodes_MC(F::AbstractArray{T, N}, pᵢ, xi_vx, icell) where {T, N}
     # a marker-chain vertex can sit exactly on the right/top boundary (x == xi_vx[i][end]),
-    # where cell_index returns the last vertex; clamp to the last cell so the corner lookup
+    # where the lookup returns the last vertex; clamp to the last cell so the corner lookup
     # (I and I+1) stays in bounds and interpolates from the edge cell
     I = ntuple(Val(N)) do i
         Base.@_inline_meta
-        clamp(cell_index(pᵢ[i], xi_vx[i], dxi[i]), 1, size(F, i) - 1)
+        # the marker's own column is a one- or two-step seed for the horizontal search;
+        # the vertical grid has no counterpart, so bisect from its middle
+        seed = ifelse(i == 1, icell, midpoint_seed(xi_vx[i]))
+        clamp(parent_cell_index(pᵢ[i], xi_vx[i], seed), 1, size(F, i) - 1)
     end
 
     # coordinates of lower-left corner of the cell
@@ -154,8 +158,12 @@ end
         Base.@_inline_meta
         xi_vx[i][I[i]]
     end
+    dxi = ntuple(Val(N)) do i
+        Base.@_inline_meta
+        cell_width(xi_vx[i], I[i])
+    end
     # F at the four centers
     Fi = extract_field_corners(F, I...)
 
-    return Fi, x_vertex_cell
+    return Fi, x_vertex_cell, dxi
 end

--- a/src/MarkerChain/Advection/backtrack.jl
+++ b/src/MarkerChain/Advection/backtrack.jl
@@ -61,24 +61,23 @@ function semilagrangian_advection!(
     h_old = copy(h_vertices)
 
     # recast integrator/timestep/grids to the topography precision so Float32 backends
-    # (e.g. Metal) are not silently promoted; `recast_grid` also rebuilds the grid ranges
-    # so they are GPU-safe when indexed directly inside the kernel (see advection!)
+    # (e.g. Metal) are not silently promoted; `backend_grid` also makes the grids GPU-safe
+    # when indexed directly inside the kernel (see advection!)
     Tc = eltype(h_vertices)
+    backend = ka_backend(h_vertices)
     method = set_precision(method, Tc)
     dt = convert(Tc, dt)
-    grid_vxi = recast_grid(grid_vxi, Tc)
-    grid = recast_grid(grid, Tc)
-    dx_chain = cell_length(chain)
+    grid_vxi = backend_grid(backend, grid_vxi, Tc)
+    grid = backend_grid(backend, grid, Tc)
 
     # compute some basic stuff
     ni = length(h_vertices)
-    dxi = compute_dx(first(grid_vxi))
     local_limits = inner_limits(grid_vxi)
 
     # launch parallel advection kernel
     launch!(
-        ka_backend(h_vertices), semilagrangian_advection_markerchain_kernel!, ni,
-        h_vertices, h_old, method, V, grid_vxi, grid, local_limits, dxi, dx_chain, dt
+        backend, semilagrangian_advection_markerchain_kernel!, ni,
+        h_vertices, h_old, method, V, grid_vxi, grid, local_limits, dt
     )
     return nothing
 end
@@ -94,8 +93,6 @@ end
         grid_vxi,
         grid,
         local_limits,
-        dxi,
-        dx_chain,
         dt,
     ) where {N, T}
     i = @index(Global)
@@ -104,14 +101,14 @@ end
     pᵢ = grid[1][i], hᵢ
     # backtrack particle position
     x_departure, y_departure = advect_particle_markerchain(
-        method, pᵢ, V, grid_vxi, local_limits, dxi, dt; backtracking = true
+        method, pᵢ, V, grid_vxi, local_limits, dt, i; backtracking = true
     )
-    h_departure = _interpolate_topography(x_departure, grid[1], h_old, dx_chain)
+    h_departure = _interpolate_topography(x_departure, grid[1], h_old, i)
     h_vertices[i] = h_departure + hᵢ - y_departure
 end
 
-@inline function _interpolate_topography(xq, xv, h, dx)
+@inline function _interpolate_topography(xq, xv, h, seed)
     x = clamp(xq, xv[1], xv[end])
-    i = clamp(cell_index(x, xv, dx), 1, length(h) - 1)
+    i = clamp(parent_cell_index(x, xv, seed), 1, length(h) - 1)
     return _interp1D(x, xv[i], xv[i + 1], h[i], h[i + 1])
 end

--- a/src/MarkerChain/Advection/interp_velocity.jl
+++ b/src/MarkerChain/Advection/interp_velocity.jl
@@ -15,21 +15,20 @@ function interpolate_velocity_to_markerchain!(
     ) where {N, T}
     (; coords, index) = chain
 
-    # recast the grid to the marker precision so the ranges are GPU-safe on Float32
-    # backends (they are indexed directly inside the kernel; see advection!)
+    # make the grid GPU-safe: it is indexed directly inside the kernel (see advection!)
     Tc = eltype(eltype(coords[1]))
-    grid_vi = recast_grid(grid_vi, Tc)
+    backend = ka_backend(chain)
+    grid_vi = backend_grid(backend, grid_vi, Tc)
 
     # compute some basic stuff
     ni = size(index, 1)
-    dxi = compute_dx(first(grid_vi))
 
     local_limits = inner_limits(grid_vi)
 
     # launch parallel advection kernel
     launch!(
-        ka_backend(chain), interpolate_velocity_to_markerchain_kernel!, ni,
-        coords, chain_V, V, index, grid_vi, local_limits, dxi,
+        backend, interpolate_velocity_to_markerchain_kernel!, ni,
+        coords, chain_V, V, index, grid_vi, local_limits,
     )
     return nothing
 end
@@ -42,7 +41,6 @@ end
         index,
         grid,
         local_limits,
-        dxi,
     ) where {N, T}
     i = @index(Global)
 
@@ -52,7 +50,7 @@ end
         # extract particle coordinates
         pᵢ = get_particle_coords(p, ipart, i)
         # interpolate velocity to particle
-        v = interp_velocity2particle_markerchain(pᵢ, grid, local_limits, dxi, V)
+        v = interp_velocity2particle_markerchain(pᵢ, grid, local_limits, V, i)
         CAI.@index chain_V[1][ipart, i] = v[1]
         CAI.@index chain_V[2][ipart, i] = v[2]
     end

--- a/src/MarkerChain/areas.jl
+++ b/src/MarkerChain/areas.jl
@@ -6,6 +6,10 @@ chain.
 
 The result is written at cell centers, vertices, and staggered velocity nodes
 using the topography currently stored in `chain`.
+
+`xvi` are the cell vertices per direction and `dxi` the matching spacings: either one
+`Number` per direction for a uniform grid, or one `AbstractVector` of per-cell widths per
+direction for a refined one.
 """
 function compute_rock_fraction!(ratios, chain::MarkerChain, xvi, dxi)
     compute_area_below_chain_centers!(ratios.center, chain, xvi, dxi)
@@ -39,39 +43,36 @@ end
     # cell origin
     ox = xv[i]
     oy = yv[j]
+    dx, dy = @dxi dxi i j
 
     p1 = GridGeometryUtils.Point(ox, topo_y[i])
     p2 = GridGeometryUtils.Point(xv[i + 1], topo_y[i + 1])
     s = Segment(p1, p2)
 
     # Rectangle's first argument is its center, not its lower-left corner.
-    r = Rectangle((ox + dxi[1] / 2, oy + dxi[2] / 2), dxi...; θ = zero(ox))
+    r = Rectangle((ox + dx / 2, oy + dy / 2), dx, dy; θ = zero(ox))
     ratio[i, j] = cell_rock_area(s, r)
 end
 
 function compute_area_below_chain_vx!(ratio_velocity, chain, xvi, dxi)
     topo_y = chain.h_vertices
     nx, ny = size(ratio_velocity)
-    mask_x = (-1, 0) .* dxi[1] ./ 2
 
     launch!(
         ka_backend(ratio_velocity), _compute_area_below_chain_vx!, (nx, ny),
-        ratio_velocity, topo_y, mask_x, xvi..., nx, dxi
+        ratio_velocity, topo_y, xvi..., nx, dxi
     )
     return nothing
 end
 
 @kernel function _compute_area_below_chain_vx!(
-        ratios::AbstractArray{T}, topo_y, mask_x, xv, yv, nx, dxi
+        ratios::AbstractArray{T}, topo_y, xv, yv, nx, dxi
     ) where {T}
     I = @index(Global, NTuple)
     i, j = I
 
-    dx, dy = dxi
-    half_dx = dx / 2
-    half_dy = dy / 2
-    c = 0
-    ω = 0 # weight for the average
+    dy = @dy dxi j
+    ω = zero(T) # total area of the sampled sub-cells
     tmp = zero(T)
     # we can cache the potential coordinates
     x, y = if 1 < i < nx
@@ -85,12 +86,12 @@ end
     ox = xv[i]
     oy = yv[j]
     for (l, ii) in enumerate((i - 1):i)
-        c += 1
         !(0 < ii < nx) && continue
 
-        ω += 1
-
-        min_corner = (ox, oy) .+ (mask_x[c], zero(T))
+        # the two halves of the control volume straddle the vertex `ox`, each half as wide
+        # as the column it is cut from and as tall as the row it sits in
+        half_dx = (@dx dxi ii) / 2
+        min_corner = (ifelse(ii < i, ox - half_dx, ox), oy)
         p1 = GridGeometryUtils.Point(x[l], y[l])
         p2 = GridGeometryUtils.Point(x[l + 1], y[l + 1])
         chain_line = Line(p1, p2)
@@ -102,10 +103,14 @@ end
 
         ## create a rectangle for the new cell
         r = Rectangle(
-            (min_corner[1] + half_dx / 2, min_corner[2] + half_dy / 2),
-            half_dx, half_dy; θ = zero(half_dx)
+            (min_corner[1] + half_dx / 2, min_corner[2] + dy / 2),
+            half_dx, dy; θ = zero(half_dx)
         )
-        tmp += cell_rock_area(s, r)
+        # the halves differ in area on a refined grid, so their fractions are
+        # area-weighted rather than averaged
+        dA = half_dx * dy
+        tmp += cell_rock_area(s, r) * dA
+        ω += dA
     end
     ratios[i, j] = tmp / ω
 end
@@ -113,54 +118,54 @@ end
 function compute_area_below_chain_vy!(ratio_velocity, chain, xvi, dxi)
     topo_y = chain.h_vertices
     nx, ny = size(ratio_velocity)
-    mask_y = (-1, 0) .* dxi[2] ./ 2
 
     launch!(
         ka_backend(ratio_velocity), _compute_area_below_chain_vy!, (nx, ny),
-        ratio_velocity, topo_y, mask_y, xvi..., ny, dxi
+        ratio_velocity, topo_y, xvi..., ny, dxi
     )
     return nothing
 end
 
 @kernel function _compute_area_below_chain_vy!(
-        ratios::AbstractArray{T}, topo_y, mask_y, xv, yv, ny, dxi
+        ratios::AbstractArray{T}, topo_y, xv, yv, ny, dxi
     ) where {T}
     I = @index(Global, NTuple)
     i, j = I
 
-    dx, dy = dxi
-    half_dx = dx / 2
-    half_dy = dy / 2
-    c = 0
-    ω = 0 # weight for the average
+    dx = @dx dxi i
+    ω = zero(T) # total area of the sampled sub-cells
     tmp = zero(T)
     # we can cache the potential coordinates
     x, y = (xv[i], xv[i + 1]), (topo_y[i], topo_y[i + 1])
     ox = xv[i]
     oy = yv[j]
 
-    for (k, jj) in enumerate((j - 1):j)
-        c += 1
+    for jj in (j - 1):j
         !(0 < jj < ny) && continue
 
-        ω += 1
-
-        min_corner = (ox, oy) .+ (zero(T), mask_y[c])
+        # the two halves of the control volume straddle the vertex `oy`, each half as tall
+        # as the row it is cut from and as wide as the column it sits in
+        half_dy = (@dy dxi jj) / 2
+        min_corner = (ox, ifelse(jj < j, oy - half_dy, oy))
         p1 = GridGeometryUtils.Point(x[1], y[1])
         p2 = GridGeometryUtils.Point(x[2], y[2])
         chain_line = Line(p1, p2)
         y1 = line(chain_line, min_corner[1])
-        y2 = line(chain_line, min_corner[1] + half_dx)
+        y2 = line(chain_line, min_corner[1] + dx)
         p1 = GridGeometryUtils.Point(min_corner[1], y1)
-        p2 = GridGeometryUtils.Point(min_corner[1] + half_dx, y2)
+        p2 = GridGeometryUtils.Point(min_corner[1] + dx, y2)
         s = Segment(p1, p2)
 
         ## create a rectangle for the new cell
         r = Rectangle(
-            (min_corner[1] + half_dx / 2, min_corner[2] + half_dy / 2),
-            half_dx, half_dy; θ = zero(half_dx)
+            (min_corner[1] + dx / 2, min_corner[2] + half_dy / 2),
+            dx, half_dy; θ = zero(dx)
         )
-        tmp += cell_rock_area(s, r)
+        # the halves differ in area on a refined grid, so their fractions are
+        # area-weighted rather than averaged
+        dA = dx * half_dy
+        tmp += cell_rock_area(s, r) * dA
+        ω += dA
     end
     ratios[i, j] = tmp / ω
 end
@@ -168,27 +173,21 @@ end
 function compute_area_below_chain_vertex!(ratio_vertex, chain, xvi, dxi)
     topo_y = chain.h_vertices
     ni = size(ratio_vertex)
-    masks_x = (-1, 0, -1, 0) .* dxi[1] ./ 2
-    masks_y = (-1, -1, 0, 0) .* dxi[2] ./ 2
 
     launch!(
         ka_backend(ratio_vertex), _compute_area_below_chain_vertex!, ni,
-        ratio_vertex, topo_y, masks_x, masks_y, xvi..., ni..., dxi
+        ratio_vertex, topo_y, xvi..., ni..., dxi
     )
     return nothing
 end
 
 @kernel function _compute_area_below_chain_vertex!(
-        ratios::AbstractArray{T}, topo_y, masks_x, masks_y, xv, yv, nx, ny, dxi
+        ratios::AbstractArray{T}, topo_y, xv, yv, nx, ny, dxi
     ) where {T}
     I = @index(Global, NTuple)
     i, j = I
 
-    dx, dy = dxi
-    half_dx = dx / 2
-    half_dy = dy / 2
-    c = 0 # linear index of the mask
-    ω = 0 # weight for the average
+    ω = zero(T) # total area of the sampled sub-cells
     tmp = zero(T)
     # we can cache the potential coordinates
     x, y = if 1 < i < nx
@@ -204,13 +203,17 @@ end
 
     for (k, jj) in enumerate((j - 1):j)
         for (l, ii) in enumerate((i - 1):i)
-            c += 1
             !(0 < ii < nx) && continue
             !(0 < jj < ny) && continue
 
-            ω += 1
-
-            min_corner = (ox, oy) .+ (masks_x[c], masks_y[c])
+            # each quadrant of the control volume is half as wide and half as tall as the
+            # cell it is cut from
+            half_dx = (@dx dxi ii) / 2
+            half_dy = (@dy dxi jj) / 2
+            min_corner = (
+                ifelse(ii < i, ox - half_dx, ox),
+                ifelse(jj < j, oy - half_dy, oy),
+            )
             p1 = GridGeometryUtils.Point(x[l], y[l])
             p2 = GridGeometryUtils.Point(x[l + 1], y[l + 1])
             chain_line = Line(p1, p2)
@@ -225,7 +228,11 @@ end
                 (min_corner[1] + half_dx / 2, min_corner[2] + half_dy / 2),
                 half_dx, half_dy; θ = zero(half_dx)
             )
-            tmp += cell_rock_area(s, r)
+            # the quadrants differ in area on a refined grid, so their fractions are
+            # area-weighted rather than averaged
+            dA = half_dx * half_dy
+            tmp += cell_rock_area(s, r) * dA
+            ω += dA
         end
     end
     ratios[i, j] = tmp / ω

--- a/src/MarkerChain/init.jl
+++ b/src/MarkerChain/init.jl
@@ -3,7 +3,8 @@
 
 Create a 2D `MarkerChain` sampled along the horizontal grid `xv`.
 
-The vertices in `xv` must be finite, strictly increasing, and uniformly spaced.
+The vertices in `xv` must be finite and strictly increasing; the spacing may be
+non-uniform, in which case each column is populated according to its own width.
 
 `nxcell` controls the initial number of markers per cell, while
 `initial_elevation` can be either a scalar or a vector specifying the initial
@@ -17,28 +18,37 @@ function init_markerchain(
         ::Type{backend}, nxcell, min_xcell, max_xcell, xv, initial_elevation
     ) where {backend}
     T = initial_elevation isa AbstractArray ? promote_type(eltype(xv), eltype(initial_elevation)) : promote_type(eltype(xv), typeof(initial_elevation))
-    xv = recast_grid(xv, T)
+    _validate_chain_grid(xv)
     nx = length(xv) - 1
     0 < nxcell ≤ max_xcell || throw(ArgumentError("nxcell must satisfy 0 < nxcell ≤ max_xcell"))
     0 < min_xcell ≤ max_xcell || throw(ArgumentError("min_xcell must satisfy 0 < min_xcell ≤ max_xcell"))
     initial_elevation isa AbstractArray && length(initial_elevation) != nx + 1 &&
         throw(DimensionMismatch("initial_elevation must have one value per grid vertex"))
-    dx = _uniform_grid_spacing(xv)
-    dx_chain = dx / (nxcell + 1)
-    initial_elevation = initial_elevation isa AbstractArray ? convert.(T, initial_elevation) : convert(T, initial_elevation)
+    # a refined grid and a vertex-wise elevation are both indexed inside the kernels below,
+    # so they have to live on the device
+    xv = device_grid(backend, xv, T)
+    initial_elevation = if initial_elevation isa AbstractArray
+        TA(backend){T}(initial_elevation)
+    else
+        convert(T, initial_elevation)
+    end
     px, py = ntuple(_ -> cell_array(backend, convert(T, NaN), (max_xcell,), (nx,)), Val(2))
     index = cell_array(backend, false, (max_xcell,), (nx,))
 
     launch!(
         ka_backend(index), fill_markerchain_coords_index!, nx,
-        px, py, index, xv, initial_elevation, dx_chain, nxcell, max_xcell
+        px, py, index, xv, initial_elevation, nxcell, max_xcell
     )
     coords = px, py
     px0, py0 = ntuple(_ -> cell_array(backend, convert(T, NaN), (max_xcell,), (nx,)), Val(2))
     copyto!(px0.data, px.data)
     copyto!(py0.data, py.data)
     coords0 = px0, py0
-    h_vertices = TA(backend)(initial_elevation isa AbstractArray ? initial_elevation : fill(initial_elevation, nx + 1))
+    h_vertices = if initial_elevation isa AbstractArray
+        copy(initial_elevation)
+    else
+        TA(backend)(fill(initial_elevation, nx + 1))
+    end
     h_vertices0 = copy(h_vertices)
 
     return MarkerChain(
@@ -47,12 +57,13 @@ function init_markerchain(
 end
 
 @kernel function fill_markerchain_coords_index!(
-        px, py, index, x, initial_elevation, dx_chain, nxcell, max_xcell
+        px, py, index, x, initial_elevation, nxcell, max_xcell
     )
     i = @index(Global)
 
     # lower-left corner of the cell
     x0 = x[i]
+    dx_chain = cell_width(x, i) / (nxcell + 1)
     # fill index array
     for ip in 1:nxcell
         CAI.@index px[ip, i] = x0 + dx_chain * ip
@@ -62,12 +73,13 @@ end
 end
 
 @kernel function fill_markerchain_coords_index!(
-        px, py, index, x, initial_elevation::AbstractArray{T, 1}, dx_chain, nxcell, max_xcell
+        px, py, index, x, initial_elevation::AbstractArray{T, 1}, nxcell, max_xcell
     ) where {T}
     i = @index(Global)
 
     # lower-left corner of the cell
     x0 = x[i]
+    dx_chain = cell_width(x, i) / (nxcell + 1)
     elevation_left = initial_elevation[i]
     elevation_right = initial_elevation[i + 1]
     # fill index array

--- a/src/MarkerChain/interp1.jl
+++ b/src/MarkerChain/interp1.jl
@@ -90,7 +90,7 @@ end
 end
 
 @inline function is_above_surface(xq, yq, coords, cell_vertices)
-    I = cell_index(xq, cell_vertices)
+    I = parent_cell_index(xq, cell_vertices, midpoint_seed(cell_vertices))
     x_cell, y_cell = coords[1][I], coords[2][I]
     return yq > interp1D_inner(xq, x_cell, y_cell, coords, I)
 end

--- a/src/MarkerChain/move.jl
+++ b/src/MarkerChain/move.jl
@@ -6,19 +6,19 @@ been updated.
 
 Markers that crossed column boundaries are moved into their destination column's
 slots, keeping the coordinate arrays consistent with the per-column occupancy
-mask. A marker may cross any number of columns in one call. The horizontal grid
-and spacing are taken from `chain.cell_vertices`.
+mask. A marker may cross any number of columns in one call. Markers whose updated
+coordinates are not finite, or which left the horizontal extent of
+`chain.cell_vertices`, are deleted.
 """
 function move_particles!(chain::MarkerChain)
     (; coords, index, cell_vertices) = chain
-    dxi = cell_length(chain)
     nxi = size(index, 1)
     grid = cell_vertices
 
     cell_jumps = similar(chain.h_vertices, Int, nxi)
     launch!(
         ka_backend(index), maximum_cell_jump!, nxi,
-        cell_jumps, coords, grid, dxi, index, nxi
+        cell_jumps, coords, grid, index
     )
     max_jump = maximum(cell_jumps)
 
@@ -30,49 +30,50 @@ function move_particles!(chain::MarkerChain)
     for offset in 1:min(ncolors, nxi)
         launch!(
             ka_backend(index), move_particles_launcher!, n_color_cells,
-            coords, grid, dxi, index, offset, nxi, ncolors
+            coords, grid, index, offset, nxi, ncolors
         )
     end
 
     return nothing
 end
 
-@kernel function maximum_cell_jump!(cell_jumps, coords, grid, dxi, index, nxi)
+@inline in_column(x, grid, i::Integer) = grid[i] ≤ x < grid[i + 1]
+
+# The cell lookup clamps, so it cannot signal that a marker left the domain; this test has
+# to run first.
+@inline outside_grid(x, grid) = x < first(grid) || x ≥ last(grid)
+
+@kernel function maximum_cell_jump!(cell_jumps, coords, grid, index)
     i = @index(Global)
-    corner_xi = corner_coordinate(grid, i)
     max_jump = 0
 
     for ip in cellaxes(index)
         doskip(index, ip, i) && continue
         pᵢ = cache_particle(coords, ip, i)
         (!isfinite(pᵢ[1]) || !isfinite(pᵢ[2])) && continue
-        isincell(pᵢ[1], corner_xi, dxi) && continue
+        in_column(pᵢ[1], grid, i) && continue
+        outside_grid(pᵢ[1], grid) && continue
 
-        new_cell = cell_index(pᵢ[1], grid, dxi)
-        if 1 ≤ new_cell ≤ nxi
-            max_jump = max(max_jump, abs(new_cell - i))
-        end
+        new_cell = parent_cell_index(pᵢ[1], grid, i)
+        max_jump = max(max_jump, abs(new_cell - i))
     end
 
     cell_jumps[i] = max_jump
 end
 
-@kernel function move_particles_launcher!(coords, grid, dxi, index, offset, nxi, ncolors)
+@kernel function move_particles_launcher!(coords, grid, index, offset, nxi, ncolors)
     i0 = @index(Global)
     i = ncolors * (i0 - 1) + offset
-    i ≤ nxi && _move_particles!(coords, grid, dxi, index, i)
+    i ≤ nxi && _move_particles!(coords, grid, index, i)
 end
 
-function _move_particles!(coords, grid, dxi, index, idx)
-    # coordinate of the lower-most-left coordinate of the parent cell
-    corner_xi = corner_coordinate(grid, idx)
-
+function _move_particles!(coords, grid, index, idx)
     # iterate over particles in child cell
     for ip in cellaxes(index)
         doskip(index, ip, idx) && continue
         pᵢ = cache_particle(coords, ip, idx)
 
-        if !isfinite(pᵢ[1]) || !isfinite(pᵢ[2])
+        if !isfinite(pᵢ[1]) || !isfinite(pᵢ[2]) || outside_grid(pᵢ[1], grid)
             ## SOMEHOW THE PARTICLE DID ESCAPE THE DOMAIN
             ## => REMOVE IT
             @inbounds CAI.@index index[ip, idx] = false
@@ -81,31 +82,22 @@ function _move_particles!(coords, grid, dxi, index, idx)
         else
             # check whether the particle is
             # within the same cell and skip it
-            isincell(pᵢ[1], corner_xi, dxi) && continue
+            in_column(pᵢ[1], grid, idx) && continue
 
-            # new cell index
-            new_cell = cell_index(pᵢ[1], grid, dxi)
+            # new cell index, seeded with the column the marker is leaving
+            new_cell = parent_cell_index(pᵢ[1], grid, idx)
 
-            if 1 ≤ new_cell < length(grid)
-                ## THE PARTICLE DID NOT ESCAPE THE DOMAIN
-                # remove particle from child cell
-                nan = convert(eltype(eltype(coords[1])), NaN)
-                @inbounds CAI.@index index[ip, idx] = false
-                @inbounds CAI.@index coords[1][ip, idx] = nan
-                @inbounds CAI.@index coords[2][ip, idx] = nan
-                # check whether there's empty space in parent cell
-                free_idx = find_free_memory(index, new_cell...)
-                iszero(free_idx) && continue
-                # move particle and its fields to the first free memory location
-                @inbounds CAI.@index index[free_idx, new_cell] = true
-                fill_particle!(coords, pᵢ, free_idx, new_cell)
-
-            else
-                ## SOMEHOW THE PARTICLE DID ESCAPE THE DOMAIN
-                ## => REMOVE IT
-                @inbounds CAI.@index index[ip, idx] = false
-                empty_particle!(coords, ip, idx)
-            end
+            # remove particle from child cell
+            nan = convert(eltype(eltype(coords[1])), NaN)
+            @inbounds CAI.@index index[ip, idx] = false
+            @inbounds CAI.@index coords[1][ip, idx] = nan
+            @inbounds CAI.@index coords[2][ip, idx] = nan
+            # check whether there's empty space in parent cell
+            free_idx = find_free_memory(index, new_cell...)
+            iszero(free_idx) && continue
+            # move particle and its fields to the first free memory location
+            @inbounds CAI.@index index[free_idx, new_cell] = true
+            fill_particle!(coords, pᵢ, free_idx, new_cell)
         end
     end
     return nothing

--- a/src/MarkerChain/resample.jl
+++ b/src/MarkerChain/resample.jl
@@ -10,7 +10,6 @@ quality and the stability of subsequent marker-chain operations.
 function resample!(chain::MarkerChain)
     (; coords, index, cell_vertices, h_vertices, min_xcell, max_xcell) = chain
     nx = length(index)
-    dx_cells = cell_length(chain)
 
     # sort marker chain
     sort_chain!(chain)
@@ -18,23 +17,23 @@ function resample!(chain::MarkerChain)
     # call kernel
     launch!(
         ka_backend(index), resample_kernel!, nx,
-        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell
     )
     return nothing
 end
 
 @kernel function resample_kernel!(
-        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell
     )
     i = @index(Global)
     resample_cell!(
-        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, dx_cells, i
+        coords, cell_vertices, h_vertices, index, min_xcell, max_xcell, i
     )
 end
 
 function resample_cell!(
         coords::NTuple{2, T}, cell_vertices, h_vertices, index,
-        min_xcell, max_xcell, dx_cells, I
+        min_xcell, max_xcell, I
     ) where {T}
 
     # cell particles coordinates
@@ -45,6 +44,7 @@ function resample_cell!(
 
     # lower-left corner of the cell
     cell_vertex = cell_vertices[I]
+    dx_cells = cell_width(cell_vertices, I)
     # number of p`articles in the cell
     np = count(index_I)
     # dx of the new chain

--- a/src/PassiveMarkers/advection.jl
+++ b/src/PassiveMarkers/advection.jl
@@ -28,11 +28,10 @@ function advection!(
     grid_vxi = recast_grid(grid_vxi, Tc)
 
     # compute some basic stuff
-    dxi = compute_dx(first(grid_vxi))
     local_limits = inner_limits(grid_vxi)
 
     # launch parallel advection kernel
-    launch!(ka_backend(particles), _advection!, np, method, coords, V, grid_vxi, local_limits, dxi, dt)
+    launch!(ka_backend(particles), _advection!, np, method, coords, V, grid_vxi, local_limits, dt)
     return nothing
 end
 
@@ -40,14 +39,17 @@ end
 
 # Runge-Kutta advection kernel for staggered grids.
 @kernel function _advection!(
-        method::AbstractAdvectionIntegrator, p, V::NTuple{N}, grid, local_limits, dxi, dt
+        method::AbstractAdvectionIntegrator, p, V::NTuple{N}, grid, local_limits, dt
     ) where {N}
     ipart = @index(Global)
 
     # cache particle coordinates
     pᵢ = get_particle_coords(p, ipart)
-    # reuses marker chain methods
-    pᵢ_new = advect_particle_markerchain(method, pᵢ, V, grid, local_limits, dxi, dt)
+    # reuses marker chain methods; passive markers carry no cell index, so the cell
+    # lookups start from the middle of the grid
+    pᵢ_new = advect_particle_markerchain(
+        method, pᵢ, V, grid, local_limits, dt, midpoint_seed(grid[1][1])
+    )
 
     # p[ipart] = SVector(p_new)
     ntuple(Val(N)) do i

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -185,3 +185,34 @@ end
         seed = div(lo + hi, 2)
     end
 end
+
+"""
+    parent_cell_index(x, xv, seed)
+
+Return the index `i` of the cell of the vertex vector `xv` that contains `x`, i.e. the `i`
+such that `xv[i] ≤ x < xv[i + 1]`, clamped to `1:length(xv) - 1`.
+
+`xv` may be uniformly spaced (an `AbstractRange`, resolved arithmetically) or refined (any
+other `AbstractVector`, resolved by bisection from the initial guess `seed`). `seed` is
+ignored in the uniform case.
+"""
+@inline parent_cell_index(x, xv::AbstractRange, seed) =
+    clamp(cell_index(x, xv, step(xv)), 1, length(xv) - 1)
+@inline function parent_cell_index(x, xv::AbstractVector, seed)
+    i = find_parent_cell_bisection(x, xv, seed)
+    # the bisection brackets inclusively at both ends; cells are half-open
+    # `[xv[i], xv[i + 1])`, so a point sitting exactly on an interior vertex
+    # belongs to the cell on its right, as it does on a range
+    return ifelse(i < length(xv) - 1 && x == xv[i + 1], i + 1, i)
+end
+
+# Seed for a lookup with no caller context: starting from the middle cell bounds the number
+# of bisection steps to log2 of the cell count.
+@inline midpoint_seed(xv::AbstractVector) = max(length(xv) >> 1, 1)
+
+"""
+    cell_width(xv, i)
+
+Width of cell `i` of the vertex vector `xv`.
+"""
+@inline cell_width(xv, i::Integer) = xv[i + 1] - xv[i]

--- a/src/launch.jl
+++ b/src/launch.jl
@@ -47,6 +47,16 @@ import KernelAbstractions
     return StepRangeLen(convert(T, first(x)), convert(T, step(x)), length(x))
 end
 
+# Counterpart of `backend_grid` for the constructors that receive the backend as a type
+# parameter rather than as a `ka_backend` instance. A refined (non-range) grid is indexed
+# directly inside kernels, so it has to live on the device.
+@inline device_grid(::Type{B}, x::AbstractRange, ::Type{T}) where {B, T} = recast_grid(x, T)
+@inline function device_grid(::Type{B}, x::AbstractVector, ::Type{T}) where {B, T}
+    A = TA(B)
+    x isa A && eltype(x) === T && return x
+    return A{T}(x)
+end
+
 @inline backend_grid(::Any, x, ::Type{T}) where {T} = convert(T, x)
 @inline backend_grid(backend, x::Tuple, ::Type{T}) where {T} = map(g -> backend_grid(backend, g, T), x)
 @inline backend_grid(::Any, x::AbstractRange, ::Type{T}) where {T} = recast_grid(x, T)

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -66,7 +66,9 @@ and a boolean occupancy mask marks which are live.
 - `h_vertices::T2`: topography sampled at the grid vertices (current step).
 - `h_vertices0::T2`: topography at the vertices from the previous step; used by
   `advect_markerchain!`/`semilagrangian_advection_markerchain!` to conserve the mean height.
-- `cell_vertices::TV`: the horizontal grid `xv` that defines the columns.
+- `cell_vertices::TV`: the horizontal grid `xv` that defines the columns. It must be
+  finite and strictly increasing; the spacing may be non-uniform, in which case every
+  operation resolves each column's width from its own pair of vertices.
 - `index::T3`: per-slot occupancy mask (`true` ⟺ the matching `coords` slot is live).
 - `min_xcell`, `max_xcell::I`: the minimum and maximum number of markers allowed per
   column; `resample!` refills depleted columns back up to `min_xcell`.
@@ -117,7 +119,7 @@ struct MarkerChain{Backend, N, I, T1, T2, T3, TV} <: AbstractParticles
 end
 
 function MarkerChain(coords, index::CPUCellArray, cell_vertices, min_xcell, max_xcell)
-    _uniform_grid_spacing(cell_vertices)
+    _validate_chain_grid(cell_vertices)
     coords0 = deepcopy.(coords)
     T = eltype(eltype(coords[1]))
     h_vertices = zeros(T, length(cell_vertices))
@@ -171,38 +173,58 @@ end
 
 unwrap_abstractarray(x::AbstractArray) = typeof(x).name.wrapper
 
-function _uniform_grid_spacing(xv)
+# Markers are bucketed into columns by looking their x-coordinate up in `cell_vertices`,
+# which requires the vertices to bracket every column unambiguously. The spacing between
+# them is free.
+function _validate_chain_grid(xv)
     ncells = length(xv) - 1
     ncells > 0 || throw(ArgumentError("cell_vertices must contain at least two vertices"))
 
     spacings = diff(xv)
-    dx = sum(spacings) / ncells
-    T = typeof(dx)
-    min_spacing = minimum(spacings)
-    max_spacing = maximum(spacings)
-    tolerance = convert(T, 32) * eps(T) * max(abs(dx), abs(min_spacing), abs(max_spacing))
-
-    isfinite(dx) && min_spacing > zero(T) ||
+    all(isfinite, spacings) && minimum(spacings) > zero(eltype(spacings)) ||
         throw(ArgumentError("MarkerChain cell_vertices must be finite and strictly increasing"))
-    maximum(abs.(spacings .- dx)) ≤ tolerance ||
-        throw(ArgumentError("MarkerChain requires uniformly spaced cell_vertices"))
 
-    return dx
+    return nothing
+end
+
+@inline _is_uniform_grid(::AbstractRange) = true
+
+function _is_uniform_grid(xv::AbstractVector)
+    spacings = diff(xv)
+    dx = sum(spacings) / length(spacings)
+    T = typeof(dx)
+    tolerance = convert(T, 32) * eps(T) *
+        max(abs(dx), abs(minimum(spacings)), abs(maximum(spacings)))
+
+    return maximum(abs.(spacings .- dx)) ≤ tolerance
 end
 
 @inline count_particles(p::AbstractParticles, icell::Vararg{Int, N}) where {N} =
     count(p.index[icell...])
 
 """
+    cell_length(chain::MarkerChain, i::Integer)
     cell_length(chain::MarkerChain)
 
-Return the horizontal cell size of a 2D marker chain.
+Return the horizontal width of column `i` of a 2D marker chain, that is
+`chain.cell_vertices[i + 1] - chain.cell_vertices[i]`.
 
-This is the spacing between consecutive entries in `chain.cell_vertices`.
-Marker chains require this grid to be uniformly spaced.
+The one-argument method returns the width shared by every column, and is therefore defined
+only when `chain.cell_vertices` is uniformly spaced; on a refined grid it throws an
+`ArgumentError`.
 """
-@inline cell_length(p::MarkerChain{B, 2}) where {B} =
-    sum(diff(p.cell_vertices)) / (length(p.cell_vertices) - 1)
+@inline cell_length(p::MarkerChain{B, 2}, i::Integer) where {B} = cell_width(p.cell_vertices, i)
+
+function cell_length(p::MarkerChain{B, 2}) where {B}
+    xv = p.cell_vertices
+    _is_uniform_grid(xv) || throw(
+        ArgumentError(
+            "cell_vertices are not uniformly spaced, so the chain has no single cell " *
+                "length; use cell_length(chain, i) for the width of column i"
+        )
+    )
+    return sum(diff(xv)) / (length(xv) - 1)
+end
 @inline cell_length_x(p::MarkerChain{B, 3}) where {B} =
     p.cell_vertices[1][2] - p.cell_vertices[1][1]
 @inline cell_length_y(p::MarkerChain{B, 3}) where {B} =

--- a/test/test_markerchain_2D.jl
+++ b/test/test_markerchain_2D.jl
@@ -75,6 +75,29 @@ function markerchain_velocity_grid(n = 17)
     return xv, yv, grid_vx, grid_vy
 end
 
+# strictly increasing, with cell widths growing left to right by a factor of `ratio`
+function markerchain_graded_grid(n, ratio = FT(4))
+    widths = FT[1 + (ratio - 1) * (i - 1) / (n - 2) for i in 1:(n - 1)]
+    xv = cumsum(vcat(zero(FT), widths))
+    return xv ./ last(xv)
+end
+
+function markerchain_expand_vector(x)
+    return vcat(x[1] - (x[2] - x[1]), x, x[end] + (x[end] - x[end - 1]))
+end
+
+# Staggered velocity grids on graded meshes refined in opposite directions, so a kernel
+# that reuses the x-component spacing for the y component gives a wrong answer.
+function markerchain_refined_velocity_grid(n = 17)
+    xv = markerchain_graded_grid(n)
+    yv = reverse(one(FT) .- markerchain_graded_grid(n))
+    xc = (xv[1:(end - 1)] .+ xv[2:end]) ./ 2
+    yc = (yv[1:(end - 1)] .+ yv[2:end]) ./ 2
+    grid_vx = TA(backend)(xv), TA(backend)(markerchain_expand_vector(yc))
+    grid_vy = TA(backend)(markerchain_expand_vector(xc)), TA(backend)(yv)
+    return xv, yv, grid_vx, grid_vy
+end
+
 function constant_markerchain_velocity(grid_vx, grid_vy, vx, vy)
     Vx = TA(backend)(fill(vx, length(grid_vx[1]), length(grid_vx[2])))
     Vy = TA(backend)(fill(vy, length(grid_vy[1]), length(grid_vy[2])))
@@ -156,6 +179,19 @@ end
         assert_chain_invariants(chain)
     end
 
+    # the initialization kernel indexes both the grid and a vertex-wise elevation, so host
+    # inputs have to reach the device
+    host_xv = collect(range(FT(0), FT(1); length = 7))
+    host_elevation = collect(range(FT(0.1), FT(0.3); length = 7))
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, host_xv, host_elevation)
+    @test chain.cell_vertices isa TA(backend)
+    @test chain.h_vertices isa TA(backend)
+    @test chain.h_vertices !== chain.h_vertices0
+    @test isapprox(
+        Array(chain.h_vertices), host_elevation; atol = chain_tol(chain), rtol = chain_tol(chain)
+    )
+    assert_chain_invariants(chain)
+
     @static if BACKEND_NAME == "CPU"
         xv = collect(range(0.0, 1.0; length = 6))
         original = init_markerchain(CPU, 3, 2, 5, xv, 0.4)
@@ -164,8 +200,19 @@ end
         @test reconstructed.coords0[1].data !== reconstructed.coords[1].data
     end
 
+    # refined grids are supported; the grid only has to be strictly increasing
     nonuniform_xv = TA(backend)(FT[0, 0.2, 0.5, 1])
-    @test_throws ArgumentError init_markerchain(backend, 2, 1, 4, nonuniform_xv, FT(0.4))
+    refined = init_markerchain(backend, 2, 1, 4, nonuniform_xv, FT(0.4))
+    assert_chain_invariants(refined)
+    @test_throws ArgumentError init_markerchain(
+        backend, 2, 1, 4, TA(backend)(FT[0, 0.5, 0.2, 1]), FT(0.4)
+    )
+    @test_throws ArgumentError init_markerchain(
+        backend, 2, 1, 4, TA(backend)(FT[0, 0.5, 0.5, 1]), FT(0.4)
+    )
+    @test_throws ArgumentError init_markerchain(
+        backend, 2, 1, 4, TA(backend)(FT[0.0]), FT(0.4)
+    )
 end
 
 @testset "MarkerChain topography reconstruction 2D" begin
@@ -591,7 +638,7 @@ end
 
     vx = Array(ratios.Vx)
     for j in axes(vx, 2)
-        expected = rock_fraction(yv[j], dy / 2)
+        expected = rock_fraction(yv[j], dy)
         @test all(vx[:, j] .≈ expected)
     end
 
@@ -695,4 +742,303 @@ end
     cell_vertices = [0.0, 1.0, 2.0, 3.0]
     @test JustPIC.first_last_particle_incell(topo_x, cell_vertices, 2) == (2, 3)
     @test JustPIC.first_last_particle_incell([0.1, 0.2], cell_vertices, 2) == (1, 0)
+end
+
+@testset "MarkerChain refined grid initialization 2D" begin
+    nxcell, min_xcell, max_xcell = 3, 2, 6
+    xv_cpu = markerchain_graded_grid(9)
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv_cpu), FT(0.4))
+
+    px, _, index, _ = host_chain(chain)
+    @test active_counts(index) == fill(nxcell, length(xv_cpu) - 1)
+    assert_chain_invariants(chain)
+
+    # each column is populated according to its own width
+    for i in axes(index, 2)
+        dx = xv_cpu[i + 1] - xv_cpu[i]
+        expected = xv_cpu[i] .+ dx .* (1:nxcell) ./ (nxcell + 1)
+        @test px[1:nxcell, i] ≈ expected
+    end
+end
+
+@testset "MarkerChain cell_length 2D" begin
+    xv_cpu = markerchain_graded_grid(9)
+    refined = init_markerchain(backend, 2, 2, 4, TA(backend)(xv_cpu), FT(0.4))
+    for i in 1:(length(xv_cpu) - 1)
+        @test cell_length(refined, i) ≈ xv_cpu[i + 1] - xv_cpu[i]
+    end
+    @test_throws "cell_vertices are not uniformly spaced" cell_length(refined)
+    @test_throws "cell_length(chain, i)" cell_length(refined)
+
+    xv_uniform = collect(range(FT(0), FT(1); length = 9))
+    dx = xv_uniform[2] - xv_uniform[1]
+    uniform = init_markerchain(backend, 2, 2, 4, TA(backend)(xv_uniform), FT(0.4))
+    @test cell_length(uniform) ≈ dx
+    @test all(cell_length(uniform, i) ≈ dx for i in 1:(length(xv_uniform) - 1))
+
+    ranged = init_markerchain(backend, 2, 2, 4, range(FT(0), FT(1); length = 9), FT(0.4))
+    @test cell_length(ranged) ≈ dx
+    @test cell_length(ranged, 1) ≈ dx
+end
+
+@testset "MarkerChain refined grid movement 2D" begin
+    xv_cpu = markerchain_graded_grid(9)
+    ncells = length(xv_cpu) - 1
+    chain = init_markerchain(backend, 1, 1, 4, TA(backend)(xv_cpu), FT(0.4))
+
+    # a marker crossing several columns of differing width lands in the right one, and one
+    # pushed past the right edge of the domain is deleted
+    set_cell_slot!(chain.coords[1], 1, 1, (xv_cpu[6] + xv_cpu[7]) / 2)
+    set_cell_slot!(chain.coords[1], 1, ncells, FT(1.5))
+    move_particles!(chain)
+
+    _, _, index, _ = host_chain(chain)
+    counts = active_counts(index)
+    @test counts[1] == 0
+    @test counts[6] == 2
+    @test counts[ncells] == 0
+    @test count(index) == ncells - 1
+    assert_chain_invariants(chain)
+end
+
+@testset "MarkerChain refined grid resample 2D" begin
+    xv_cpu = markerchain_graded_grid(9)
+    ncells = length(xv_cpu) - 1
+    min_xcell, max_xcell = 4, 6
+    # the widest column is several times the narrowest, so a single global spacing cannot
+    # satisfy both
+    @test (xv_cpu[end] - xv_cpu[end - 1]) > 3 * (xv_cpu[2] - xv_cpu[1])
+
+    chain = init_markerchain(backend, 2, min_xcell, max_xcell, TA(backend)(xv_cpu), FT(0.2))
+    resample!(chain)
+    px, py, index, _ = host_chain(chain)
+    @test active_counts(index) == fill(min_xcell, ncells)
+    @test all(py[index] .≈ FT(0.2))
+    assert_chain_invariants(chain)
+
+    for i in (1, ncells)
+        dx = (xv_cpu[i + 1] - xv_cpu[i]) / (min_xcell + 1)
+        @test diff(px[1:min_xcell, i]) ≈ fill(dx, min_xcell - 1)
+    end
+end
+
+@testset "MarkerChain refined grid velocity interpolation 2D" begin
+    xv, _, grid_vx, grid_vy = markerchain_refined_velocity_grid()
+    grid_vi = grid_vx, grid_vy
+    chain = init_markerchain(backend, 3, 2, 6, TA(backend)(xv), FT(0.45))
+    chain_V = ntuple(_ -> cell_array(backend, FT(0), (chain.max_xcell,), size(chain.index)), Val(2))
+
+    vx_field(x, y) = FT(0.1) * x + FT(0.2) * y
+    vy_field(x, y) = FT(-0.3) * x + FT(0.05) * y
+    gvx, gvy = Array.(grid_vx), Array.(grid_vy)
+    V = (
+        TA(backend)([vx_field(x, y) for x in gvx[1], y in gvx[2]]),
+        TA(backend)([vy_field(x, y) for x in gvy[1], y in gvy[2]]),
+    )
+
+    interpolate_velocity_to_markerchain!(chain, chain_V, V, grid_vi)
+    px, py, index, _ = host_chain(chain)
+    Vx_chain = host_data(chain_V[1])
+    Vy_chain = host_data(chain_V[2])
+
+    # bilinear interpolation of a linear field is exact only when each component is
+    # normalized by the spacing of its own staggered grid
+    atol = FT === Float32 ? 1.0f-5 : 1.0e-12
+    @test all(isapprox.(Vx_chain[index], vx_field.(px[index], py[index]); atol, rtol = atol))
+    @test all(isapprox.(Vy_chain[index], vy_field.(px[index], py[index]); atol, rtol = atol))
+end
+
+@testset "MarkerChain refined grid advection 2D" begin
+    xv, yv, grid_vx, grid_vy = markerchain_refined_velocity_grid()
+    grid_vi = grid_vx, grid_vy
+    grid = TA(backend)(xv), TA(backend)(yv)
+    nxcell, min_xcell, max_xcell = 3, 2, 6
+    elevation = FT(0.45)
+    dt = FT(0.1)
+    vx, vy = FT(0.03), FT(-0.02)
+    V = constant_markerchain_velocity(grid_vx, grid_vy, vx, vy)
+
+    reference = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv), elevation)
+    px0, py0, index0, _ = host_chain(reference)
+
+    for method in (Euler(), RungeKutta2(), RungeKutta4())
+        chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv), elevation)
+        advection!(chain, method, V, grid_vi, dt)
+        px, py, index, _ = host_chain(chain)
+        atol = chain_tol(chain)
+        @test index == index0
+        @test all(isapprox.(px[index], px0[index0] .+ vx * dt; atol, rtol = atol))
+        @test all(isapprox.(py[index], py0[index0] .+ vy * dt; atol, rtol = atol))
+    end
+
+    # a uniform vertical velocity lifts a flat surface by vy*dt
+    chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv), elevation)
+    Vup = constant_markerchain_velocity(grid_vx, grid_vy, FT(0), vy)
+    JustPIC.semilagrangian_advection!(chain, RungeKutta2(), Vup, grid_vi, grid, dt)
+    @test isapprox(
+        Array(chain.h_vertices), fill(elevation + vy * dt, length(xv));
+        atol = (FT === Float32 ? 1.0f-5 : 1.0e-6)
+    )
+
+    # both wrappers conserve the mean height
+    Vright = constant_markerchain_velocity(grid_vx, grid_vy, FT(0.05), FT(0))
+    for advect! in (
+            (c) -> advect_markerchain!(c, RungeKutta2(), Vright, grid_vi, FT(0.05)),
+            (c) -> semilagrangian_advection_markerchain!(c, RungeKutta2(), Vright, grid_vi, grid, FT(0.05)),
+        )
+        chain = init_markerchain(backend, nxcell, min_xcell, max_xcell, TA(backend)(xv), elevation)
+        h0 = chain_mean(Array(chain.h_vertices))
+        for _ in 1:10
+            advect!(chain)
+        end
+        h = Array(chain.h_vertices)
+        @test all(isfinite, h)
+        @test isapprox(chain_mean(h), h0; atol = chain_tol(chain), rtol = chain_tol(chain))
+        assert_chain_invariants(chain)
+    end
+end
+
+@testset "MarkerChain refined grid rock fraction 2D" begin
+    n = 9
+    xv = markerchain_graded_grid(n)
+    yv = reverse(one(FT) .- markerchain_graded_grid(n))
+    dx = diff(xv)
+    dy = diff(yv)
+    xvi = TA(backend)(xv), TA(backend)(yv)
+    dxi = TA(backend)(dx), TA(backend)(dy)
+
+    make_ratios() = (
+        center = TA(backend)(zeros(FT, n - 1, n - 1)),
+        vertex = TA(backend)(zeros(FT, n, n)),
+        Vx = TA(backend)(zeros(FT, n, n - 1)),
+        Vy = TA(backend)(zeros(FT, n - 1, n)),
+    )
+
+    chain = init_markerchain(backend, 3, 2, 6, TA(backend)(xv), FT(0.5))
+
+    copyto!(chain.h_vertices, TA(backend)(fill(FT(2), n)))
+    ratios = make_ratios()
+    compute_rock_fraction!(ratios, chain, xvi, dxi)
+    for field in (ratios.center, ratios.vertex, ratios.Vx, ratios.Vy)
+        @test all(Array(field) .≈ 1)
+    end
+
+    copyto!(chain.h_vertices, TA(backend)(fill(FT(-1), n)))
+    ratios = make_ratios()
+    compute_rock_fraction!(ratios, chain, xvi, dxi)
+    for field in (ratios.center, ratios.vertex, ratios.Vx, ratios.Vy)
+        @test all(Array(field) .≈ 0)
+    end
+
+    # flat interface: every control volume gets the fraction of its own height below `h`
+    h = FT(0.42)
+    copyto!(chain.h_vertices, TA(backend)(fill(h, n)))
+    ratios = make_ratios()
+    compute_rock_fraction!(ratios, chain, xvi, dxi)
+    rock_fraction(y_bottom, height) = clamp((h - y_bottom) / height, zero(FT), one(FT))
+
+    center = Array(ratios.center)
+    for j in axes(center, 2)
+        @test all(center[:, j] .≈ rock_fraction(yv[j], dy[j]))
+    end
+
+    vx = Array(ratios.Vx)
+    for j in axes(vx, 2)
+        @test all(vx[:, j] .≈ rock_fraction(yv[j], dy[j]))
+    end
+
+    vertex = Array(ratios.vertex)
+    vy = Array(ratios.Vy)
+    for j in axes(vertex, 2)
+        # the two halves straddling vertex `j` are cut from rows of different height, so
+        # the control-volume fraction weights them by area, not by count
+        expected = if j == firstindex(yv)
+            rock_fraction(yv[j], dy[j] / 2)
+        elseif j == lastindex(yv)
+            rock_fraction(yv[j] - dy[j - 1] / 2, dy[j - 1] / 2)
+        else
+            (
+                dy[j - 1] * rock_fraction(yv[j] - dy[j - 1] / 2, dy[j - 1] / 2) +
+                    dy[j] * rock_fraction(yv[j], dy[j] / 2)
+            ) / (dy[j - 1] + dy[j])
+        end
+        @test all(vertex[:, j] .≈ expected)
+        @test all(vy[:, j] .≈ expected)
+    end
+
+    for field in (ratios.center, ratios.vertex, ratios.Vx, ratios.Vy)
+        data = Array(field)
+        @test all(isfinite, data)
+        @test all(0 .≤ data .≤ 1)
+    end
+end
+
+# Exact fraction of the rectangle [x0, x1] x [y0, y1] lying below the line y = h0 + s * x.
+# The integrand is piecewise linear with breakpoints where the line crosses the floor and
+# the ceiling, so the trapezoid rule over those nodes is exact.
+function markerchain_rock_fraction(h0, s, x0, x1, y0, y1)
+    g(x) = clamp((h0 + s * x - y0) / (y1 - y0), zero(FT), one(FT))
+    breaks = iszero(s) ? FT[] : FT[(y0 - h0) / s, (y1 - h0) / s]
+    nodes = sort(vcat(FT[x0, x1], filter(x -> x0 < x < x1, breaks)))
+    total = zero(FT)
+    for k in 1:(length(nodes) - 1)
+        total += (g(nodes[k]) + g(nodes[k + 1])) * (nodes[k + 1] - nodes[k]) / 2
+    end
+    return total / (x1 - x0)
+end
+
+@testset "MarkerChain sloping interface rock fraction 2D" begin
+    n = 9
+    xv = markerchain_graded_grid(n)
+    yv = reverse(one(FT) .- markerchain_graded_grid(n))
+    dx = diff(xv)
+    dy = diff(yv)
+    xvi = TA(backend)(xv), TA(backend)(yv)
+    dxi = TA(backend)(dx), TA(backend)(dy)
+
+    h0, slope = FT(0.25), FT(0.5)
+    chain = init_markerchain(backend, 3, 2, 6, TA(backend)(xv), FT(0.5))
+    copyto!(chain.h_vertices, TA(backend)(h0 .+ slope .* xv))
+
+    ratios = (
+        center = TA(backend)(zeros(FT, n - 1, n - 1)),
+        vertex = TA(backend)(zeros(FT, n, n)),
+        Vx = TA(backend)(zeros(FT, n, n - 1)),
+        Vy = TA(backend)(zeros(FT, n - 1, n)),
+    )
+    compute_rock_fraction!(ratios, chain, xvi, dxi)
+
+    # extents of the staggered control volumes, truncated at the domain boundary; the
+    # sub-cells tiling them have unequal areas on a graded grid, so a count-weighted average
+    # of their fractions is wrong
+    left(i) = i == 1 ? xv[1] : xv[i] - dx[i - 1] / 2
+    right(i) = i == n ? xv[n] : xv[i] + dx[i] / 2
+    bottom(j) = j == 1 ? yv[1] : yv[j] - dy[j - 1] / 2
+    top(j) = j == n ? yv[n] : yv[j] + dy[j] / 2
+
+    atol = FT === Float32 ? 1.0f-4 : 1.0e-9
+
+    center = Array(ratios.center)
+    for j in axes(center, 2), i in axes(center, 1)
+        expected = markerchain_rock_fraction(h0, slope, xv[i], xv[i + 1], yv[j], yv[j + 1])
+        @test isapprox(center[i, j], expected; atol, rtol = atol)
+    end
+
+    vertex = Array(ratios.vertex)
+    for j in axes(vertex, 2), i in axes(vertex, 1)
+        expected = markerchain_rock_fraction(h0, slope, left(i), right(i), bottom(j), top(j))
+        @test isapprox(vertex[i, j], expected; atol, rtol = atol)
+    end
+
+    vx = Array(ratios.Vx)
+    for j in axes(vx, 2), i in axes(vx, 1)
+        expected = markerchain_rock_fraction(h0, slope, left(i), right(i), yv[j], yv[j + 1])
+        @test isapprox(vx[i, j], expected; atol, rtol = atol)
+    end
+
+    vy = Array(ratios.Vy)
+    for j in axes(vy, 2), i in axes(vy, 1)
+        expected = markerchain_rock_fraction(h0, slope, xv[i], xv[i + 1], bottom(j), top(j))
+        @test isapprox(vy[i, j], expected; atol, rtol = atol)
+    end
 end


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

`MarkerChain` required `cell_vertices` to be uniformly spaced and threw an `ArgumentError`
otherwise, even though the rest of the package already supports refined grids. This PR lifts
that restriction: `cell_vertices` now only has to be finite and strictly increasing, and
every operation resolves each column's width from its own pair of vertices.

## Cell lookup

Two primitives in `src/Utils.jl` replace the constant-width arithmetic:

- `parent_cell_index(x, xv, seed)` — arithmetic on an `AbstractRange`, seeded bisection
  (`find_parent_cell_bisection`, already in the package) on any other `AbstractVector`.
- `cell_width(xv, i)` — the width of column `i`.

Two traps worth flagging for review:

- The bisection brackets `xv[i] ≤ x ≤ xv[i+1]` inclusively, whereas cells are half-open
  `[xv[i], xv[i+1])`. `parent_cell_index` reconciles the two, so a marker sitting exactly on
  an interior vertex lands in the same column on both grid types. Without this,
  `move_particles!` relocates such a marker on every call.
- `find_parent_cell_bisection` clamps, so it cannot signal that a marker left the domain.
  `move_particles!` therefore tests `outside_grid` *before* the lookup, which keeps
  out-of-domain deletion working.

## Public API

- `cell_length(chain, i)` (new) returns the width of column `i`.
- `cell_length(chain)` still returns the single shared width, but throws an `ArgumentError`
  on a refined grid rather than silently returning `xv[2] - xv[1]`.

No other signature changed, and no previously-working call breaks: a refined chain could not
be constructed before.

## Bugs fixed along the way

**Staggered velocity spacing.** `advection!` and `interpolate_velocity_to_markerchain!`
computed `dxi = compute_dx(first(grid_vi))` — the `grid_vx` spacing only — and used it for
*both* velocity components. On a staggered refined grid `grid_vx` and `grid_vy` have
different spacings, so `Vy` was interpolated at the wrong scale. Rather than threading a
per-component `dxi`, `corner_field_nodes_MC` now reads each cell's width off the vertex
vector it belongs to, which makes the mistake unrepresentable. The regression test uses a
*linear* velocity field; a constant field does not catch this, because lerp of equal corner
values is spacing-independent.

**Rock fractions were averaged, not area-weighted.** `cell_rock_area` returns a fraction, so
a control volume tiled by sub-cells has fraction `sum(f_q * A_q) / sum(A_q)`. The vertex, Vx
and Vy kernels divided by the sub-cell *count* instead, which equals that only when the
sub-cells have equal area — true on a uniform grid, false on a refined one. No-op on uniform
grids.

**Vx and Vy sampled half of their control volume.** Both kernels used a half-width rectangle
in the direction they do *not* straddle, so `Vx` covered only `[yv[j], yv[j] + dy[j]/2]` of
row `j` and `Vy` only `[xv[i], xv[i] + dx[i]/2]` of column `i`, while the vertex kernel
covered its whole control volume. They now span the full row and the full column
respectively. **This changes results on uniform grids too** — on the graded test
configuration the ratios move by up to 4.3e-1 (`Vx`) and 1.8e-1 (`Vy`). It also makes `Vx`
agree with `center` in the same row for a horizontal interface, which it previously did not.
Worth a second opinion if anything downstream is calibrated against the old values.

**Host arrays reaching kernels.** `init_markerchain` passed a host `initial_elevation` vector
straight into its kernel while transferring `h_vertices`, and the advection entry points used
`recast_grid` (a no-op on non-ranges) where a device transfer was needed. Both now go through
`device_grid`/`backend_grid`.

## Verification

The four `compute_rock_fraction!` outputs are checked against an exact integration of a
linear interface over each control volume: the integrand is piecewise linear with breakpoints
where the interface crosses the floor and the ceiling, so the trapezoid rule over those nodes
is exact. All four now match to machine precision (~1e-16); the previous kernels missed by up
to 4.2e-1.

`test/test_markerchain_2D.jl` gained eight testsets — refined-grid initialization,
`cell_length`, movement, resample, velocity interpolation, advection, rock fraction, and the
sloping-interface rock fraction described above. The full suite is green on CPU with
`Float64` and `Float32`, and under `--check-bounds=yes`.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [x] New tests (either assessing the correct behaviour of new internal functions or the correctness of a miniapps or benchmarks) were added, or old tests were updated
- [x] Affected miniapps have also been updated
- [x] The new feature was added in a way that does not break public API
- [x] New documentation related to the new feature was added
- [x] The new code follows the [contributor guidelines](https://github.com/JuliaGeodynamics/JustPIC.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
