### PR TITLE
Fix cell-centered field dispatch in inject_particles_phase!

### DIFF
--- a/src/Particles/injection.jl
+++ b/src/Particles/injection.jl
@@ -287,7 +287,10 @@ function _inject_particles_phase!(
     )
     # coordinates of the lower-left corner of the cell
     xvi = corner_coordinate(grid, idx_cell)
-    ni_cells = size(index)
+    # Number of cells, i.e. the size of a cell-centered field. `index` carries a halo, so
+    # its own size is `ni .+ 2`; comparing a field against that below would never match and
+    # every field would be treated as vertex-centered.
+    ni_cells = inner_size(index)
 
     # coordinates of the lower-left corner of the cell quadrants
     xvi_quadrants = quadrant_corners(xvi, di_quadrant)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -184,6 +184,7 @@ end
         lo > hi && return clamp(seed, 1, length(x) - 1)
         seed = div(lo + hi, 2)
     end
+    return
 end
 
 """

--- a/test/test_3D.jl
+++ b/test/test_3D.jl
@@ -169,6 +169,45 @@ end
     @test count(index_cpu[2, 2, 2]) ≥ min_xcell
 end
 
+@testset "Particle injection with a cell-centered field 3D" begin
+    nxcell, max_xcell, min_xcell = 12, 24, 6
+    nx, ny, nz = 8, 6, 10
+    ni = nx, ny, nz
+    Li = 1.0, 1.0, 1.0
+    xvi = ntuple(i -> LinRange(0, Li[i], ni[i] + 1), Val(3))
+    dxi = ntuple(i -> xvi[i][2] - xvi[i][1], Val(3))
+    xci = ntuple(i -> LinRange(dxi[i] / 2, Li[i] - dxi[i] / 2, ni[i]), Val(3))
+    grid_vx = xvi[1], expand_range(xci[2]), expand_range(xci[3])
+    grid_vy = expand_range(xci[1]), xvi[2], expand_range(xci[3])
+    grid_vz = expand_range(xci[1]), expand_range(xci[2]), xvi[3]
+
+    particles = JustPIC.init_particles(
+        backend, nxcell, max_xcell, min_xcell, grid_vx, grid_vy, grid_vz,
+    )
+    pPhases, pT = JustPIC.init_cell_arrays(particles, Val(2))
+    fill!(pPhases.data, 1)
+
+    # Empty a block of interior cells so injection fires there. It has to reach the last
+    # cell along a dimension: that is where interpolating a cell-centered field reads one
+    # index past its end if the field is mistaken for a vertex-centered one.
+    cells = [(i, j, k) for i in 4:6, j in 3:6, k in 5:7]
+    for c in cells, ip in 1:max_xcell
+        CAI.@index particles.index[ip, c...] = false
+    end
+
+    # A constant field must survive interpolation exactly, so every injected particle
+    # carries that constant.
+    F_center = TA(backend)(fill(FT(7.5), ni))
+    JustPIC.inject_particles_phase!(particles, pPhases, (pT,), (F_center,))
+
+    index_cpu, pT_cpu = Array(particles.index), Array(pT)
+    injected = [
+        pT_cpu[c...][ip] for c in cells for ip in 1:max_xcell if index_cpu[c...][ip]
+    ]
+    @test !isempty(injected)
+    @test all(x -> x ≈ FT(7.5), injected)
+end
+
 @testset "Subgrid diffusion 3D" begin
     nxcell, max_xcell, min_xcell = 24, 24, 1
     n = 5 # number of vertices


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

### Problem

`_inject_particles_phase!` decides whether to interpolate each grid field from the cell
centers or from the vertices by comparing that field's size against `ni_cells`:

```julia
ni_cells = size(index)
...
if sz == ni_cells
    # cell-centered path
else
    # vertex path
end
```

`index` is the particle index array and carries a halo, so `size(index)` is `ni .+ 2`.
A cell-centered field is `ni` and a vertex-centered one is `ni .+ 1`, so the comparison
can never hold: the cell-centered branch is unreachable and every field is interpolated
as if it lived on the vertices.

That is harmless for a vertex field. For a cell-centered field the vertex path reads one
index past the end:

```
BoundsError: attempt to access 128×4×64 Array{Float64, 3} at index [92, 5, 24]
```

It only fires when an under-populated cell sits at the **last** index along a dimension,
which is why it can go unnoticed on cubic grids but shows up immediately on thin ones —
this surfaced on a 3D subduction model with `ny = 4`, passing `stokes.τ.xx` and friends
as fields.

### Fix

Use `inner_size(index)`. It is already applied to the same array for the launch
dimensions elsewhere in this file:

```julia
ni_cells = inner_size(index)
```

Only the guard was wrong — the body of the cell-centered branch was already written for
cell counts. It clamps the index to `sz .- 1` and interpolates against `grid_center`
(`particles.xci`), whose length is `ni`.

### Test

Adds `"Particle injection with a cell-centered field 3D"` to `test/test_3D.jl`. It empties
a block of interior cells, injects while interpolating a **constant** cell-centered field,
and checks that every injected particle carries that constant — so it verifies the values,
not just the absence of a throw. This matters because the cell-centered branch was dead
code and had never executed before.

The emptied block deliberately includes the last cell along a dimension; a test that only
empties mid-domain cells passes even without the fix.

Verified to error with a `BoundsError` before the change and pass after it.

### Observation, not addressed here

Separately: if *ghost* cells are under-populated, injection appears to overrun even a
vertex-centered field (reading `ny + 2`). I did not investigate whether that is a real
defect or a state that cannot arise in normal use, so it is left out of this PR.

